### PR TITLE
feat: stress test suite and health endpoints (issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,142 @@ For production deployment behind a reverse proxy, see [deploy/README.md](deploy/
 
 ---
 
+## Health Monitoring
+
+TEREDACTA includes built-in health endpoints for load balancers, monitoring tools, and stress testing.
+
+### Endpoints
+
+| Endpoint | Purpose | Auth Required |
+|---|---|---|
+| `GET /health/live` | Liveness probe — is the event loop alive? | No |
+| `GET /health/ready` | Readiness probe — can the server handle requests? | No |
+
+**Liveness** returns `{"status": "ok"}` if the process is responsive. Use this for Caddy/load balancer health checks and uptime monitors.
+
+**Readiness** checks DB pool availability and SSE subscriber count, returning `healthy`, `degraded`, or `unhealthy`:
+
+```json
+{
+  "status": "healthy",
+  "worker_pid": 12345,
+  "checks": {
+    "db_pool": {"status": "ok", "idle": 6, "in_use": 2, "capacity": 8},
+    "sse": {"status": "ok", "subscribers": 1},
+    "uptime_seconds": 3600.5
+  }
+}
+```
+
+Detailed metrics (pool counts, PID, uptime) are only included for localhost or authenticated admin requests. Public responses return only `{"status": "healthy"}`.
+
+### Thresholds
+
+| Component | Healthy | Degraded | Unhealthy |
+|---|---|---|---|
+| DB pool (available connections) | ≥3 | 1–2 | 0 |
+| SSE subscribers | <20 | 20–100 | >100 |
+
+Thresholds are configurable in `teredacta.yaml`:
+
+```yaml
+health_pool_degraded_threshold: 3   # available connections below this = degraded
+health_sse_degraded_threshold: 20   # subscribers at or above this = degraded
+```
+
+### Caddy Integration
+
+Add health checking to your Caddyfile reverse_proxy block:
+
+```
+reverse_proxy localhost:8000 {
+    health_uri /health/live
+    health_interval 5s
+}
+```
+
+See [deploy/README.md](deploy/README.md) for the full Caddy setup.
+
+---
+
+## Stress Testing
+
+TEREDACTA includes a comprehensive stress test suite for verifying stability under load. There are two complementary tools:
+
+### Pytest Stress Tests (CI-runnable)
+
+Fast, deterministic tests targeting specific failure modes. These run against an in-process test server with synthetic data — no external server needed.
+
+```bash
+# Install dev dependencies (if not already)
+pip install -e ".[dev]"
+
+# Run all stress tests
+pytest -m stress -v
+
+# Run a specific category
+pytest -m stress teredacta/tests/test_stress_db_pool.py -v
+pytest -m stress teredacta/tests/test_stress_compound_deadlock.py -v
+```
+
+**What's tested:**
+
+| Test File | What It Verifies |
+|---|---|
+| `test_stress_db_pool.py` | 50 threads competing for 8 connections, recovery after burst, no leaks on timeout |
+| `test_stress_sse.py` | 200+ subscribers, abandoned queue cleanup via broadcast eviction, rapid connect/disconnect cycling |
+| `test_stress_thread_pool.py` | Health endpoints respond when thread pool executor is fully saturated |
+| `test_stress_compound_deadlock.py` | **Production failure mode** — all executor threads blocked on pool.acquire() while event loop remains responsive |
+| `test_stress_mixed.py` | Concurrent HTTP requests + SSE + health checks don't deadlock; recovery after load |
+
+Stress tests are excluded from the default `pytest` run (via marker config). They only run when explicitly selected with `-m stress`.
+
+### Locust Load Tests (live server)
+
+Realistic sustained load testing against a running TEREDACTA instance — local or remote.
+
+```bash
+# Install locust dependencies
+pip install -e ".[stress]"
+
+# Run against local server (uses LoadTestShape: 30s ramp → 4min sustained → 30s cool-down → 15s recovery)
+locust -f stress/locustfile.py --headless --host http://localhost:8000
+
+# Run against your VPS
+export STRESS_ADMIN_PASSWORD=your-admin-password
+locust -f stress/locustfile.py --headless --host https://your-server.com
+
+# Interactive web UI (open http://localhost:8089)
+locust -f stress/locustfile.py --host https://your-server.com
+```
+
+**Load profile:**
+
+| Phase | Duration | Users |
+|---|---|---|
+| Warm-up | 0–30s | 0 → 200 |
+| Sustained | 30s–4m30s | 200 |
+| Cool-down | 4m30s–5m | 200 → 0 |
+| Recovery | 5m–5m15s | 1 (health monitor only) |
+
+**User profiles:**
+
+| Profile | Weight | Behavior |
+|---|---|---|
+| WebUser | 60% | Browses documents, recoveries, highlights, entity explorer |
+| SSEUser | 15% | Opens SSE connections (10–60s), mix of graceful/ungraceful disconnects |
+| AdminUser | 20% | Dashboard, daemon status, config, logs |
+| HealthMonitor | 5% | Polls `/health/live` and `/health/ready`, flags sustained unhealthy status |
+
+**Success criteria:**
+- Liveness probe never fails
+- Readiness probe does not report "unhealthy" for more than 60 seconds
+- Server recovers to "healthy" after load subsides
+
+See [stress/README.md](stress/README.md) for full configuration options.
+
+---
+
 ## Troubleshooting
 
 ### "Database not found" on startup

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -65,3 +65,29 @@ Set admin password via environment variable:
 ```bash
 export TEREDACTA_ADMIN_PASSWORD=your-secure-password
 ```
+
+## Health Checks
+
+TEREDACTA exposes health endpoints for monitoring:
+
+- `GET /health/live` — Liveness probe (event loop alive?)
+- `GET /health/ready` — Readiness probe (DB pool, SSE status)
+
+### Caddy Health Check
+
+Add to your Caddyfile reverse_proxy block:
+
+```
+reverse_proxy localhost:8000 {
+    health_uri /health/live
+    health_interval 5s
+}
+```
+
+This lets Caddy detect and route around unresponsive workers.
+
+### External Monitoring
+
+Point your monitoring tool (UptimeRobot, Healthchecks.io, etc.) at:
+- Liveness: `https://your-domain.com/health/live`
+- Readiness: `https://your-domain.com/health/ready`

--- a/docs/superpowers/plans/2026-04-01-stress-test-suite.md
+++ b/docs/superpowers/plans/2026-04-01-stress-test-suite.md
@@ -24,8 +24,8 @@
 | `teredacta/tests/test_stress_thread_pool.py` | Thread pool exhaustion stress tests |
 | `teredacta/tests/test_stress_compound_deadlock.py` | Production failure mode reproduction |
 | `teredacta/tests/test_stress_mixed.py` | Combined workload stress tests |
-| `stress/locustfile.py` | Locust user classes and load test scenarios |
-| `stress/config.py` | Locust configuration (target URL, credentials, thresholds) |
+| `stress/locustfile.py` | Locust user classes, LoadTestShape, and load test scenarios |
+| `stress/stress_config.py` | Locust configuration (target URL, credentials, thresholds) |
 | `stress/README.md` | How to run stress tests locally and against VPS |
 
 ### Modified Files
@@ -125,7 +125,7 @@ Add to `teredacta/db_pool.py` after the `close()` method (after line 89):
         """
         idle = self._pool.qsize()
         size = self._size
-        return {"idle": idle, "in_use": size - idle, "capacity": self._max_size}
+        return {"idle": idle, "in_use": max(0, size - idle), "capacity": self._max_size}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -170,18 +170,23 @@ from teredacta.sse import SSEManager
 
 
 class TestSSESubscriberCount:
-    def test_subscriber_count_zero(self):
+    """Tests must be async because SSEManager.subscribe() calls asyncio.create_task()."""
+
+    @pytest.mark.asyncio
+    async def test_subscriber_count_zero(self):
         sse = SSEManager(poll_interval=1.0, unob=None)
         assert sse.subscriber_count == 0
 
-    def test_subscriber_count_after_subscribe(self):
+    @pytest.mark.asyncio
+    async def test_subscriber_count_after_subscribe(self):
         sse = SSEManager(poll_interval=1.0, unob=None)
         q = sse.subscribe()
         assert sse.subscriber_count == 1
         sse.unsubscribe(q)
         assert sse.subscriber_count == 0
 
-    def test_subscriber_count_multiple(self):
+    @pytest.mark.asyncio
+    async def test_subscriber_count_multiple(self):
         sse = SSEManager(poll_interval=1.0, unob=None)
         q1 = sse.subscribe()
         q2 = sse.subscribe()
@@ -351,18 +356,47 @@ class TestHealthEndpoints:
         # Force unhealthy by exhausting the pool
         app = health_client.app
         unob = app.state.unob
-        # Trigger pool creation and exhaust it
+        # Trigger pool creation and exhaust all 8 connections
         conns = []
         for _ in range(8):
             conns.append(unob._get_db())
         resp = health_client.get("/health/ready")
-        assert resp.status_code == 200  # 0 idle but pool just created, may still be "degraded" or "unhealthy"
+        assert resp.status_code == 503  # 0 available = unhealthy
         data = resp.json()
+        assert data["status"] == "unhealthy"
         assert data["checks"]["db_pool"]["idle"] == 0
         assert data["checks"]["db_pool"]["in_use"] == 8
         # Release
         for c in conns:
             unob._release_db(c)
+
+    def test_liveness_works_when_readiness_unhealthy(self, health_client):
+        """Liveness probe returns 200 even when readiness is unhealthy."""
+        app = health_client.app
+        unob = app.state.unob
+        # Exhaust pool to make readiness unhealthy
+        conns = [unob._get_db() for _ in range(8)]
+        # Readiness should be 503
+        assert health_client.get("/health/ready").status_code == 503
+        # Liveness should still be 200
+        resp = health_client.get("/health/live")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+        for c in conns:
+            unob._release_db(c)
+
+    def test_readiness_timeout_returns_503(self, health_client):
+        """If readiness checks hang beyond 1 second, return 503."""
+        import asyncio
+        from unittest.mock import patch
+
+        async def slow_checks(*args, **kwargs):
+            await asyncio.sleep(5)  # Will exceed 1s timeout
+
+        with patch("teredacta.routers.health._readiness_checks", slow_checks):
+            resp = health_client.get("/health/ready")
+            assert resp.status_code == 503
+            assert resp.json()["status"] == "unhealthy"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -386,8 +420,6 @@ from fastapi.responses import JSONResponse
 
 router = APIRouter()
 
-_startup_time = time.monotonic()
-
 
 @router.get("/live")
 async def liveness():
@@ -407,16 +439,20 @@ async def _readiness_checks(request: Request) -> JSONResponse:
     config = request.app.state.config
     unob = request.app.state.unob
     sse = getattr(request.app.state, "sse", None)
-    is_local = getattr(request.client, "host", None) in ("127.0.0.1", "localhost", "::1", "testclient")
+    # request.client can be None behind some reverse proxy configs
+    client_host = getattr(request.client, "host", None) if request.client else None
+    is_local = client_host in ("127.0.0.1", "localhost", "::1", "testclient")
     is_admin = getattr(request.state, "is_admin", False)
     show_details = is_local or is_admin
 
     # DB pool check
     pool_data = unob.pool_status()
     if pool_data is None:
-        pool_check = {"status": "ok", "idle": 0, "in_use": 0, "capacity": 8}
+        # Pool not yet initialized — no queries made yet, healthy
+        pool_check = {"status": "ok", "idle": 0, "in_use": 0, "capacity": 0}
     else:
-        available = pool_data["idle"] + (pool_data["capacity"] - pool_data["in_use"] - pool_data["idle"])
+        # available = idle connections + uncreated slots
+        available = pool_data["capacity"] - pool_data["in_use"]
         if available >= config.health_pool_degraded_threshold:
             pool_status = "ok"
         elif available >= 1:
@@ -455,7 +491,7 @@ async def _readiness_checks(request: Request) -> JSONResponse:
             "checks": {
                 "db_pool": pool_check,
                 "sse": sse_check,
-                "uptime_seconds": round(time.monotonic() - _startup_time, 1),
+                "uptime_seconds": round(time.monotonic() - request.app.state.startup_time, 1),
             },
         }
     else:
@@ -477,10 +513,13 @@ to:
     from teredacta.routers import dashboard, documents, groups, recoveries, pdf, queue, summary, admin, explore, highlights, api, health
 ```
 
-And add the mount after the SSE router mount (after line 51):
+And add the mount and startup time after the SSE router mount (after line 51):
 ```python
     app.include_router(health.router, prefix="/health")
+    app.state.startup_time = time.monotonic()
 ```
+
+Also add `import time` to the top of `app.py` (after `import logging`).
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -512,15 +551,17 @@ class _HealthLogFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         msg = record.getMessage()
-        if "/health/" in msg:
+        if " /health/" in msg:
             return False
         return True
 ```
 
-Add inside `create_app()`, before the middleware definition (before line 40):
+Add inside `create_app()`, before the middleware definition (before line 40). Guard against accumulation from repeated `create_app()` calls in tests:
 
 ```python
-    logging.getLogger("uvicorn.access").addFilter(_HealthLogFilter())
+    _access_logger = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, _HealthLogFilter) for f in _access_logger.filters):
+        _access_logger.addFilter(_HealthLogFilter())
 ```
 
 - [ ] **Step 2: Run existing tests to verify nothing broke**
@@ -577,7 +618,7 @@ markers = [
     "stress: stress tests (deselected by default, run with: pytest -m stress)",
 ]
 addopts = "-m 'not stress'"
-asyncio_mode = "auto"
+asyncio_mode = "strict"
 ```
 
 - [ ] **Step 3: Install updated deps**
@@ -770,8 +811,10 @@ from teredacta.sse import SSEManager
 @pytest.mark.stress
 @pytest.mark.timeout(90)
 class TestSSESaturation:
+    """All tests are async because SSEManager.subscribe() calls asyncio.create_task()."""
 
-    def test_200_subscribers_no_leak(self):
+    @pytest.mark.asyncio
+    async def test_200_subscribers_no_leak(self):
         """Open 200 subscribers, unsubscribe all, verify cleanup."""
         sse = SSEManager(poll_interval=1.0, unob=None)
         queues = [sse.subscribe() for _ in range(200)]
@@ -781,11 +824,26 @@ class TestSSESaturation:
             sse.unsubscribe(q)
         assert sse.subscriber_count == 0
 
-    def test_ungraceful_disconnect_cleanup_via_queuefull(self):
-        """Abandoned queues are cleaned up when QueueFull is hit during broadcast."""
-        sse = SSEManager(poll_interval=1.0, unob=None)
+    @pytest.mark.asyncio
+    async def test_ungraceful_disconnect_cleanup_via_poll_loop(self):
+        """Abandoned queues are cleaned up by the real _poll_loop broadcast."""
+        from unittest.mock import MagicMock
 
-        # Subscribe 10 queues, then "abandon" 5 (never read from them)
+        # Create a mock unob that returns changing stats each call
+        mock_unob = MagicMock()
+        call_count = 0
+        def changing_stats():
+            nonlocal call_count
+            call_count += 1
+            return {"total_documents": call_count}
+        def changing_daemon():
+            return "running"
+        mock_unob.get_stats = changing_stats
+        mock_unob.get_daemon_status = changing_daemon
+
+        sse = SSEManager(poll_interval=0.01, unob=mock_unob)
+
+        # Subscribe 10 queues — 5 active (we drain), 5 abandoned
         active_queues = []
         abandoned_queues = []
         for i in range(10):
@@ -797,33 +855,26 @@ class TestSSESaturation:
 
         assert sse.subscriber_count == 10
 
-        # Fill abandoned queues to capacity (maxsize=100)
-        # Simulate broadcasts until QueueFull triggers cleanup
-        for i in range(101):
-            event = f"data: {{\"seq\": {i}}}\n\n"
-            dead = []
-            for q in list(sse._subscribers):
-                try:
-                    q.put_nowait(event)
-                except asyncio.QueueFull:
-                    dead.append(q)
-            for q in dead:
-                sse._subscribers.discard(q)
-            # Drain active queues to prevent them from filling
+        # Let the real poll loop run and broadcast events.
+        # Drain active queues so they don't fill up.
+        # Abandoned queues will fill (maxsize=100) and get evicted.
+        for _ in range(150):
+            await asyncio.sleep(0.02)
             for q in active_queues:
                 try:
                     q.get_nowait()
                 except asyncio.QueueEmpty:
                     pass
 
-        # Abandoned queues should have been evicted
+        # Abandoned queues should have been evicted by _poll_loop
         assert sse.subscriber_count == 5
 
         for q in active_queues:
             sse.unsubscribe(q)
         assert sse.subscriber_count == 0
 
-    def test_rapid_connect_disconnect_cycle(self):
+    @pytest.mark.asyncio
+    async def test_rapid_connect_disconnect_cycle(self):
         """1000 rapid subscribe/unsubscribe cycles with no resource leak."""
         sse = SSEManager(poll_interval=1.0, unob=None)
 
@@ -833,12 +884,13 @@ class TestSSESaturation:
 
         assert sse.subscriber_count == 0
 
-    def test_subscribe_without_iterating_persists(self):
+    @pytest.mark.asyncio
+    async def test_subscribe_without_iterating_persists(self):
         """A queue subscribed but never iterated persists until QueueFull.
 
         This documents the known behavior: if subscribe() is called
         but the StreamingResponse generator never starts, the queue
-        stays in _subscribers until broadcasts fill it to capacity.
+        stays in _subscribers until broadcasts fill it to capacity (100).
         """
         sse = SSEManager(poll_interval=1.0, unob=None)
         orphan = sse.subscribe()
@@ -846,17 +898,15 @@ class TestSSESaturation:
         # The orphan queue exists
         assert sse.subscriber_count == 1
 
-        # It won't be cleaned up until QueueFull (100 events)
-        for i in range(99):
-            try:
-                orphan.put_nowait(f"data: {i}\n\n")
-            except asyncio.QueueFull:
-                break
+        # Fill to capacity (maxsize=100). subscribe() doesn't put
+        # anything in the queue, so we need 100 puts to fill it.
+        for i in range(100):
+            orphan.put_nowait(f"data: {i}\n\n")
 
-        # Still there (not yet full — 1 from subscribe + 99 = 100)
+        # Still there (full but not yet evicted — eviction happens on next broadcast)
         assert sse.subscriber_count == 1
 
-        # One more triggers QueueFull during next broadcast
+        # One more triggers QueueFull — simulating what _poll_loop does
         dead = []
         try:
             orphan.put_nowait("data: overflow\n\n")
@@ -896,7 +946,56 @@ git commit -m "test: add SSE saturation stress tests"
 
 ---
 
-### Task 9: Stress test — Thread pool exhaustion
+### Task 9: Add shared stress test fixtures to conftest.py
+
+**Files:**
+- Modify: `teredacta/tests/conftest.py`
+
+This avoids duplicating the full DB schema across every stress test file.
+
+- [ ] **Step 1: Add stress_db and stress_app fixtures to conftest.py**
+
+Append to `teredacta/tests/conftest.py`:
+
+```python
+@pytest.fixture
+def stress_db(tmp_path, mock_db):
+    """Reuse mock_db schema with optional seed data for stress tests."""
+    return mock_db
+
+
+@pytest.fixture
+def stress_app(tmp_path, stress_db):
+    """App for stress tests using the shared mock_db schema."""
+    cfg = TeredactaConfig(
+        unobfuscator_path=str(tmp_path),
+        unobfuscator_bin="echo",
+        db_path=str(stress_db),
+        pdf_cache_dir=str(tmp_path / "pdf_cache"),
+        output_dir=str(tmp_path / "output"),
+        log_path=str(tmp_path / "unobfuscator.log"),
+        host="127.0.0.1",
+        port=8000,
+    )
+    from teredacta.app import create_app
+    return create_app(cfg)
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing broke**
+
+Run: `pytest teredacta/tests/test_health.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/conftest.py
+git commit -m "test: add shared stress_db and stress_app fixtures"
+```
+
+---
+
+### Task 10: Stress test — Thread pool exhaustion
 
 **Files:**
 - Create: `teredacta/tests/test_stress_thread_pool.py`
@@ -909,102 +1008,45 @@ Create `teredacta/tests/test_stress_thread_pool.py`:
 """Stress tests for thread pool exhaustion scenarios."""
 
 import asyncio
-import sqlite3
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import httpx
 
-from teredacta.config import TeredactaConfig
-
 
 @pytest.mark.stress
 @pytest.mark.timeout(90)
 class TestThreadPoolExhaustion:
 
-    @pytest.fixture
-    def stress_app(self, tmp_path):
-        """Create app with a small, pinned executor for deterministic tests."""
-        db_path = tmp_path / "test.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "CREATE TABLE documents (id TEXT PRIMARY KEY, source TEXT, "
-            "extracted_text TEXT, text_processed BOOLEAN DEFAULT 0, "
-            "pdf_processed BOOLEAN DEFAULT 0, original_filename TEXT, "
-            "page_count INTEGER, size_bytes INTEGER)"
-        )
-        conn.execute(
-            "CREATE TABLE match_groups (group_id INTEGER PRIMARY KEY, "
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE merge_results (group_id INTEGER PRIMARY KEY, "
-            "merged_text TEXT, recovered_count INTEGER DEFAULT 0, "
-            "previous_recovered_count INTEGER DEFAULT 0, total_redacted INTEGER DEFAULT 0, "
-            "source_doc_ids TEXT, created_at DATETIME, updated_at DATETIME, "
-            "output_generated BOOLEAN DEFAULT 0, recovered_segments TEXT, "
-            "soft_recovered_count INTEGER DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE document_fingerprints (doc_id TEXT PRIMARY KEY, "
-            "minhash_sig BLOB, shingle_count INTEGER, created_at DATETIME)"
-        )
-        conn.execute(
-            "CREATE TABLE jobs (job_id INTEGER PRIMARY KEY, stage TEXT, "
-            "payload TEXT, priority INTEGER DEFAULT 0, status TEXT DEFAULT 'pending', "
-            "error TEXT, created_at DATETIME, updated_at DATETIME)"
-        )
-        conn.execute(
-            "CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE release_batches (batch_id TEXT PRIMARY KEY, "
-            "first_seen_at DATETIME, fully_indexed BOOLEAN DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE match_group_members (group_id INTEGER, doc_id TEXT, "
-            "similarity REAL, added_at DATETIME, PRIMARY KEY (group_id, doc_id))"
-        )
-        conn.close()
-
-        cfg = TeredactaConfig(
-            unobfuscator_path=str(tmp_path),
-            unobfuscator_bin="echo",
-            db_path=str(db_path),
-            pdf_cache_dir=str(tmp_path / "pdf_cache"),
-            output_dir=str(tmp_path / "output"),
-            log_path=str(tmp_path / "unobfuscator.log"),
-            host="127.0.0.1",
-            port=8000,
-        )
-        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
-        (tmp_path / "output").mkdir(exist_ok=True)
-        (tmp_path / "unobfuscator.log").touch()
-
-        from teredacta.app import create_app
-        return create_app(cfg)
+    @pytest.fixture(autouse=True)
+    def pin_executor(self):
+        """Pin executor to small size and restore original after test."""
+        loop = asyncio.get_event_loop()
+        original_executor = loop._default_executor
+        small_executor = ThreadPoolExecutor(max_workers=4)
+        loop.set_default_executor(small_executor)
+        yield small_executor
+        # Restore original executor
+        loop.set_default_executor(original_executor)
+        small_executor.shutdown(wait=False, cancel_futures=True)
 
     @pytest.mark.asyncio
-    async def test_liveness_responds_when_executor_saturated(self, stress_app):
+    async def test_liveness_responds_when_executor_saturated(self, stress_app, pin_executor):
         """Liveness probe works even when executor threads are all blocked."""
-        # Pin a small executor
-        small_executor = ThreadPoolExecutor(max_workers=4)
         loop = asyncio.get_running_loop()
-        loop.set_default_executor(small_executor)
 
-        # Saturate the executor with blocking tasks
-        block_event = asyncio.Event()
+        # Saturate the executor with short blocking tasks (2s, not 10s)
+        barrier = threading.Event()
         futures = []
         for _ in range(4):
-            fut = loop.run_in_executor(None, lambda: asyncio.run(block_event.wait()) if False else time.sleep(10))
+            fut = loop.run_in_executor(None, lambda: barrier.wait(timeout=2.0))
             futures.append(fut)
 
         try:
-            # Give tasks a moment to claim all executor threads
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
 
-            # Liveness should still respond (it's pure async, no executor)
             async with httpx.AsyncClient(
                 transport=httpx.ASGITransport(app=stress_app),
                 base_url="http://testserver",
@@ -1016,25 +1058,22 @@ class TestThreadPoolExhaustion:
                 assert resp.status_code == 200
                 assert resp.json()["status"] == "ok"
         finally:
-            # Cancel blocking tasks
-            for fut in futures:
-                fut.cancel()
-            small_executor.shutdown(wait=False, cancel_futures=True)
+            barrier.set()  # Unblock all threads
+            await asyncio.gather(*futures, return_exceptions=True)
 
     @pytest.mark.asyncio
-    async def test_readiness_responds_when_executor_saturated(self, stress_app):
+    async def test_readiness_responds_when_executor_saturated(self, stress_app, pin_executor):
         """Readiness probe works even when executor threads are all blocked."""
-        small_executor = ThreadPoolExecutor(max_workers=4)
         loop = asyncio.get_running_loop()
-        loop.set_default_executor(small_executor)
+        barrier = threading.Event()
 
         futures = []
         for _ in range(4):
-            fut = loop.run_in_executor(None, lambda: time.sleep(10))
+            fut = loop.run_in_executor(None, lambda: barrier.wait(timeout=2.0))
             futures.append(fut)
 
         try:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.3)
 
             async with httpx.AsyncClient(
                 transport=httpx.ASGITransport(app=stress_app),
@@ -1045,12 +1084,10 @@ class TestThreadPoolExhaustion:
                     timeout=3.0,
                 )
                 assert resp.status_code == 200
-                # Pool not initialized yet, so healthy
                 assert resp.json()["status"] == "healthy"
         finally:
-            for fut in futures:
-                fut.cancel()
-            small_executor.shutdown(wait=False, cancel_futures=True)
+            barrier.set()
+            await asyncio.gather(*futures, return_exceptions=True)
 ```
 
 - [ ] **Step 2: Run to verify tests pass**
@@ -1067,7 +1104,7 @@ git commit -m "test: add thread pool exhaustion stress tests"
 
 ---
 
-### Task 10: Stress test — Compound deadlock (production failure mode)
+### Task 11: Stress test — Compound deadlock (production failure mode)
 
 **Files:**
 - Create: `teredacta/tests/test_stress_compound_deadlock.py`
@@ -1087,15 +1124,12 @@ also need executor threads. This test verifies:
 """
 
 import asyncio
-import sqlite3
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import httpx
 
-from teredacta.config import TeredactaConfig
 from teredacta.db_pool import ConnectionPool
 
 
@@ -1103,81 +1137,24 @@ from teredacta.db_pool import ConnectionPool
 @pytest.mark.timeout(90)
 class TestCompoundDeadlock:
 
-    @pytest.fixture
-    def stress_setup(self, tmp_path):
-        """Create app and pool with small sizes for deterministic testing."""
-        db_path = tmp_path / "test.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.execute(
-            "CREATE TABLE documents (id TEXT PRIMARY KEY, source TEXT, "
-            "extracted_text TEXT, text_processed BOOLEAN DEFAULT 0, "
-            "pdf_processed BOOLEAN DEFAULT 0, original_filename TEXT, "
-            "page_count INTEGER, size_bytes INTEGER)"
-        )
-        conn.execute(
-            "CREATE TABLE match_groups (group_id INTEGER PRIMARY KEY, "
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE merge_results (group_id INTEGER PRIMARY KEY, "
-            "merged_text TEXT, recovered_count INTEGER DEFAULT 0, "
-            "previous_recovered_count INTEGER DEFAULT 0, total_redacted INTEGER DEFAULT 0, "
-            "source_doc_ids TEXT, created_at DATETIME, updated_at DATETIME, "
-            "output_generated BOOLEAN DEFAULT 0, recovered_segments TEXT, "
-            "soft_recovered_count INTEGER DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE document_fingerprints (doc_id TEXT PRIMARY KEY, "
-            "minhash_sig BLOB, shingle_count INTEGER, created_at DATETIME)"
-        )
-        conn.execute(
-            "CREATE TABLE jobs (job_id INTEGER PRIMARY KEY, stage TEXT, "
-            "payload TEXT, priority INTEGER DEFAULT 0, status TEXT DEFAULT 'pending', "
-            "error TEXT, created_at DATETIME, updated_at DATETIME)"
-        )
-        conn.execute(
-            "CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)"
-        )
-        conn.execute(
-            "CREATE TABLE release_batches (batch_id TEXT PRIMARY KEY, "
-            "first_seen_at DATETIME, fully_indexed BOOLEAN DEFAULT 0)"
-        )
-        conn.execute(
-            "CREATE TABLE match_group_members (group_id INTEGER, doc_id TEXT, "
-            "similarity REAL, added_at DATETIME, PRIMARY KEY (group_id, doc_id))"
-        )
-        conn.close()
-
-        cfg = TeredactaConfig(
-            unobfuscator_path=str(tmp_path),
-            unobfuscator_bin="echo",
-            db_path=str(db_path),
-            pdf_cache_dir=str(tmp_path / "pdf_cache"),
-            output_dir=str(tmp_path / "output"),
-            log_path=str(tmp_path / "unobfuscator.log"),
-            host="127.0.0.1",
-            port=8000,
-        )
-        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
-        (tmp_path / "output").mkdir(exist_ok=True)
-        (tmp_path / "unobfuscator.log").touch()
-
-        from teredacta.app import create_app
-        app = create_app(cfg)
-        return app, db_path
+    @pytest.fixture(autouse=True)
+    def pin_executor(self):
+        """Pin executor to 8 threads (same as pool size) and restore after."""
+        loop = asyncio.get_event_loop()
+        original_executor = loop._default_executor
+        small_executor = ThreadPoolExecutor(max_workers=8)
+        loop.set_default_executor(small_executor)
+        yield small_executor
+        loop.set_default_executor(original_executor)
+        small_executor.shutdown(wait=False, cancel_futures=True)
 
     @pytest.mark.asyncio
-    async def test_event_loop_survives_compound_deadlock(self, stress_setup):
+    async def test_event_loop_survives_compound_deadlock(self, stress_app, stress_db):
         """Event loop stays responsive even when executor + pool are both saturated."""
-        app, db_path = stress_setup
-
-        # Pin executor to 8 threads (same as pool size — worst case)
-        small_executor = ThreadPoolExecutor(max_workers=8)
         loop = asyncio.get_running_loop()
-        loop.set_default_executor(small_executor)
 
         # Create a pool we can control
-        pool = ConnectionPool(str(db_path), max_size=8, read_only=True)
+        pool = ConnectionPool(str(stress_db), max_size=8, read_only=True)
 
         # Phase 1: Hold all 8 pool connections
         held_conns = [pool.acquire(timeout=5.0) for _ in range(8)]
@@ -1198,7 +1175,7 @@ class TestCompoundDeadlock:
 
         # Phase 3: Verify event loop is still alive
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
+            transport=httpx.ASGITransport(app=stress_app),
             base_url="http://testserver",
         ) as client:
             resp = await asyncio.wait_for(
@@ -1217,7 +1194,6 @@ class TestCompoundDeadlock:
 
         # Some may have acquired (after release), some may have timed out
         acquired = [r for r in results if not isinstance(r, Exception)]
-        timed_out = [r for r in results if isinstance(r, (TimeoutError, Exception))]
 
         # Release any that acquired
         for conn in acquired:
@@ -1226,20 +1202,17 @@ class TestCompoundDeadlock:
         # Phase 6: Verify recovery
         status = pool.pool_status()
         assert status["in_use"] == 0
-        assert status["idle"] == 8  # all returned
 
         # New acquire should work instantly
         conn = pool.acquire(timeout=1.0)
         pool.release(conn)
 
         pool.close()
-        small_executor.shutdown(wait=False, cancel_futures=True)
 
     @pytest.mark.asyncio
-    async def test_health_reports_degraded_during_contention(self, stress_setup):
+    async def test_health_reports_degraded_during_contention(self, stress_app):
         """Health endpoint reports correct status during compound contention."""
-        app, db_path = stress_setup
-        unob = app.state.unob
+        unob = stress_app.state.unob
 
         # Force pool creation by making a query
         conn = unob._get_db()
@@ -1251,7 +1224,7 @@ class TestCompoundDeadlock:
             held.append(unob._get_db())
 
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
+            transport=httpx.ASGITransport(app=stress_app),
             base_url="http://testserver",
         ) as client:
             resp = await client.get("/health/ready")
@@ -1265,7 +1238,7 @@ class TestCompoundDeadlock:
 
         # After release — should be healthy again
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
+            transport=httpx.ASGITransport(app=stress_app),
             base_url="http://testserver",
         ) as client:
             resp = await client.get("/health/ready")
@@ -1287,7 +1260,7 @@ git commit -m "test: add compound deadlock stress test (production failure mode)
 
 ---
 
-### Task 11: Stress test — Mixed workload
+### Task 12: Stress test — Mixed workload
 
 **Files:**
 - Create: `teredacta/tests/test_stress_mixed.py`
@@ -1305,91 +1278,31 @@ import sqlite3
 import pytest
 import httpx
 
-from teredacta.config import TeredactaConfig
-
 
 @pytest.mark.stress
 @pytest.mark.timeout(90)
 class TestMixedWorkload:
 
     @pytest.fixture
-    def mixed_app(self, tmp_path):
-        """App with populated DB for mixed workload testing."""
-        db_path = tmp_path / "test.db"
-        conn = sqlite3.connect(str(db_path))
-        conn.executescript("""
-            CREATE TABLE documents (
-                id TEXT PRIMARY KEY, source TEXT, extracted_text TEXT,
-                text_processed BOOLEAN DEFAULT 0, pdf_processed BOOLEAN DEFAULT 0,
-                original_filename TEXT, page_count INTEGER, size_bytes INTEGER,
-                release_batch TEXT, description TEXT, pdf_url TEXT,
-                indexed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                text_source TEXT, ocr_processed BOOLEAN DEFAULT 0, page_tags TEXT
-            );
-            CREATE TABLE match_groups (
-                group_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0
-            );
-            CREATE TABLE match_group_members (
-                group_id INTEGER, doc_id TEXT, similarity REAL,
-                added_at DATETIME, PRIMARY KEY (group_id, doc_id)
-            );
-            CREATE TABLE merge_results (
-                group_id INTEGER PRIMARY KEY, merged_text TEXT,
-                recovered_count INTEGER DEFAULT 0, previous_recovered_count INTEGER DEFAULT 0,
-                total_redacted INTEGER DEFAULT 0, source_doc_ids TEXT,
-                created_at DATETIME, updated_at DATETIME,
-                output_generated BOOLEAN DEFAULT 0,
-                recovered_segments TEXT, soft_recovered_count INTEGER DEFAULT 0
-            );
-            CREATE TABLE document_fingerprints (
-                doc_id TEXT PRIMARY KEY, minhash_sig BLOB,
-                shingle_count INTEGER, created_at DATETIME
-            );
-            CREATE TABLE jobs (
-                job_id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT,
-                payload TEXT, priority INTEGER DEFAULT 0,
-                status TEXT DEFAULT 'pending', error TEXT,
-                created_at DATETIME, updated_at DATETIME
-            );
-            CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT);
-            CREATE TABLE release_batches (
-                batch_id TEXT PRIMARY KEY, first_seen_at DATETIME,
-                fully_indexed BOOLEAN DEFAULT 0
-            );
-        """)
-        # Seed with enough data for non-trivial queries
+    def seeded_app(self, stress_app, stress_db):
+        """Seed the stress_db with document data for mixed workload."""
+        conn = sqlite3.connect(str(stress_db))
         rows = [
             (f"doc-{i}", f"source-{i % 5}", f"text content {i} " * 20,
-             1, 0, f"file_{i}.pdf", (i % 10) + 1, i * 100,
-             f"batch-{i % 3}", None, None, None, None, None)
+             1, 0, f"file_{i}.pdf", (i % 10) + 1, i * 100)
             for i in range(1000)
         ]
         conn.executemany(
-            "INSERT INTO documents VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", rows
+            "INSERT OR IGNORE INTO documents "
+            "(id, source, extracted_text, text_processed, pdf_processed, "
+            "original_filename, page_count, size_bytes) VALUES (?,?,?,?,?,?,?,?)", rows
         )
         conn.commit()
         conn.close()
-
-        cfg = TeredactaConfig(
-            unobfuscator_path=str(tmp_path),
-            unobfuscator_bin="echo",
-            db_path=str(db_path),
-            pdf_cache_dir=str(tmp_path / "pdf_cache"),
-            output_dir=str(tmp_path / "output"),
-            log_path=str(tmp_path / "unobfuscator.log"),
-            host="127.0.0.1",
-            port=8000,
-        )
-        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
-        (tmp_path / "output").mkdir(exist_ok=True)
-        (tmp_path / "unobfuscator.log").touch()
-
-        from teredacta.app import create_app
-        return create_app(cfg)
+        return stress_app
 
     @pytest.mark.asyncio
-    async def test_concurrent_requests_and_sse(self, mixed_app):
+    async def test_concurrent_requests_and_sse(self, seeded_app):
         """Simultaneous HTTP requests + SSE subscribers don't deadlock."""
         errors = []
 
@@ -1421,7 +1334,7 @@ class TestMixedWorkload:
         health_results = []
 
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=mixed_app),
+            transport=httpx.ASGITransport(app=seeded_app),
             base_url="http://testserver",
         ) as client:
             # Launch mixed workload
@@ -1440,11 +1353,11 @@ class TestMixedWorkload:
             assert result["status"] in ("healthy", "degraded")
 
     @pytest.mark.asyncio
-    async def test_recovery_after_load(self, mixed_app):
+    async def test_recovery_after_load(self, seeded_app):
         """Health returns to healthy after load subsides."""
 
         async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=mixed_app),
+            transport=httpx.ASGITransport(app=seeded_app),
             base_url="http://testserver",
         ) as client:
             # Phase 1: Apply load
@@ -1476,20 +1389,20 @@ git commit -m "test: add mixed workload stress tests"
 
 ---
 
-### Task 12: Locust load test suite
+### Task 13: Locust load test suite
 
 **Files:**
-- Create: `stress/config.py`
+- Create: `stress/stress_config.py`
 - Create: `stress/locustfile.py`
 - Create: `stress/README.md`
 
-- [ ] **Step 1: Create stress/config.py**
+- [ ] **Step 1: Create stress/stress_config.py**
 
 ```bash
 mkdir -p stress
 ```
 
-Create `stress/config.py`:
+Create `stress/stress_config.py` (named `stress_config` to avoid shadowing `teredacta.config`):
 
 ```python
 """Configuration for locust stress tests."""
@@ -1515,6 +1428,12 @@ READINESS_UNHEALTHY_SECONDS = 60  # Sustained unhealthy = test failure
 # SSE connection parameters
 SSE_MIN_HOLD_SECONDS = 10
 SSE_MAX_HOLD_SECONDS = 60
+
+# Load test phases (seconds)
+RAMP_UP_SECONDS = 30
+SUSTAINED_SECONDS = 240
+RAMP_DOWN_SECONDS = 30
+RECOVERY_SECONDS = 15
 ```
 
 - [ ] **Step 2: Create stress/locustfile.py**
@@ -1532,31 +1451,76 @@ Run with Web UI:
 """
 
 import logging
+import math
 import random
 import time
 
-from locust import HttpUser, between, events, task
-from locust.exception import StopUser
+import gevent
+from locust import HttpUser, LoadTestShape, between, events, task
 
-from config import (
+from stress_config import (
     ADMIN_PASSWORD,
     ADMIN_USER_WEIGHT,
     HEALTH_MONITOR_WEIGHT,
+    RAMP_DOWN_SECONDS,
+    RAMP_UP_SECONDS,
     READINESS_UNHEALTHY_SECONDS,
+    RECOVERY_SECONDS,
     SSE_MAX_HOLD_SECONDS,
     SSE_MIN_HOLD_SECONDS,
     SSE_USER_WEIGHT,
+    SUSTAINED_SECONDS,
     WEB_USER_WEIGHT,
 )
 
 logger = logging.getLogger(__name__)
 
-# Track health status transitions globally
+# Track health status transitions globally.
+# Safe under gevent: cooperative scheduling, no I/O between read-modify-write.
 _health_tracker = {
     "last_healthy": time.monotonic(),
     "unhealthy_since": None,
     "liveness_failures": 0,
 }
+
+
+class StressTestShape(LoadTestShape):
+    """Custom load shape with warm-up, sustained, cool-down, and recovery phases.
+
+    Phase 1 (0-30s):      Ramp up from 0 to 200 users
+    Phase 2 (30s-4m30s):  Sustained at 200 users
+    Phase 3 (4m30s-5m):   Ramp down from 200 to 0
+    Phase 4 (5m-5m15s):   Recovery — only HealthMonitor users remain
+    """
+    MAX_USERS = 200
+    SPAWN_RATE = 10
+
+    def tick(self):
+        run_time = self.get_run_time()
+
+        if run_time < RAMP_UP_SECONDS:
+            # Phase 1: Ramp up
+            users = min(self.MAX_USERS, math.ceil(run_time * self.SPAWN_RATE))
+            return (users, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS:
+            # Phase 2: Sustained load
+            return (self.MAX_USERS, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS + RAMP_DOWN_SECONDS:
+            # Phase 3: Ramp down
+            elapsed_in_phase = run_time - RAMP_UP_SECONDS - SUSTAINED_SECONDS
+            fraction_remaining = 1 - (elapsed_in_phase / RAMP_DOWN_SECONDS)
+            users = max(1, math.ceil(self.MAX_USERS * fraction_remaining))
+            return (users, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS + RAMP_DOWN_SECONDS + RECOVERY_SECONDS:
+            # Phase 4: Recovery — keep minimal users for health monitoring
+            return (1, 1)
+
+        else:
+            # Done
+            return None
 
 
 class WebUser(HttpUser):
@@ -1584,7 +1548,6 @@ class WebUser(HttpUser):
 
     @task(1)
     def view_document_detail(self):
-        # Try a document ID — may 404 if data is sparse, that's fine
         doc_id = f"doc-{random.randint(1, 100)}"
         self.client.get(f"/documents/{doc_id}", name="/documents/[id]")
 
@@ -1593,7 +1556,8 @@ class SSEUser(HttpUser):
     """Simulates an admin subscribing to SSE stats."""
 
     weight = SSE_USER_WEIGHT
-    wait_time = between(SSE_MIN_HOLD_SECONDS, SSE_MAX_HOLD_SECONDS)
+    # Short wait between reconnections — hold time is inside the task
+    wait_time = between(1, 3)
 
     def on_start(self):
         """Authenticate to get admin session cookie."""
@@ -1601,6 +1565,7 @@ class SSEUser(HttpUser):
             "/admin/login",
             data={"password": ADMIN_PASSWORD},
             name="/admin/login",
+            allow_redirects=False,
         )
 
     @task
@@ -1613,6 +1578,7 @@ class SSEUser(HttpUser):
             with self.client.get(
                 "/sse/stats",
                 stream=True,
+                timeout=hold_time + 5,  # Hard timeout to prevent blocking beyond hold_time
                 name="/sse/stats",
                 catch_response=True,
             ) as resp:
@@ -1628,10 +1594,6 @@ class SSEUser(HttpUser):
         except Exception as e:
             logger.debug("SSE connection ended: %s", e)
 
-        # Occasionally simulate ungraceful disconnect (just stop — no close)
-        if random.random() < 0.3:
-            return  # ungraceful: let connection be GC'd
-
 
 class AdminUser(HttpUser):
     """Simulates admin dashboard usage."""
@@ -1644,6 +1606,7 @@ class AdminUser(HttpUser):
             "/admin/login",
             data={"password": ADMIN_PASSWORD},
             name="/admin/login",
+            allow_redirects=False,
         )
 
     @task(3)
@@ -1655,8 +1618,8 @@ class AdminUser(HttpUser):
         self.client.get("/admin/daemon/status")
 
     @task(2)
-    def view_queue(self):
-        self.client.get("/admin/queue")
+    def view_entity_index_status(self):
+        self.client.get("/admin/entity-index/status")
 
     @task(1)
     def view_config(self):
@@ -1720,7 +1683,7 @@ class HealthMonitor(HttpUser):
 
 @events.test_stop.add_listener
 def on_test_stop(environment, **kwargs):
-    """Report health summary at end of test."""
+    """Report health summary at end of test. process_exit_code only works in headless mode."""
     tracker = _health_tracker
     logger.info("=== Health Summary ===")
     logger.info("Liveness failures: %d", tracker["liveness_failures"])
@@ -1760,8 +1723,8 @@ teredacta run
 
 Then run the stress tests:
 ```bash
-# Headless (CI mode)
-locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
+# Headless (CI mode) — uses StressTestShape for phases
+locust -f stress/locustfile.py --headless --host http://localhost:8000
 
 # With web UI (interactive)
 locust -f stress/locustfile.py --host http://localhost:8000
@@ -1772,7 +1735,7 @@ locust -f stress/locustfile.py --host http://localhost:8000
 
 ```bash
 export STRESS_ADMIN_PASSWORD=your-admin-password
-locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host https://your-vps.example.com
+locust -f stress/locustfile.py --headless --host https://your-vps.example.com
 ```
 
 ### With web UI
@@ -1781,6 +1744,15 @@ locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host https://your
 locust -f stress/locustfile.py --host https://your-vps.example.com
 ```
 Open http://localhost:8089 to configure users, spawn rate, and watch results.
+
+## Load Phases (StressTestShape)
+
+| Phase | Duration | Users | Description |
+|---|---|---|---|
+| Warm-up | 0-30s | 0→200 | Ramp up at 10 users/sec |
+| Sustained | 30s-4m30s | 200 | Full load |
+| Cool-down | 4m30s-5m | 200→0 | Ramp down |
+| Recovery | 5m-5m15s | 1 | Verify health returns to healthy |
 
 ## Configuration
 
@@ -1797,7 +1769,7 @@ Environment variables:
 |---|---|---|
 | WebUser | 60% | Browses public pages (documents, recoveries, highlights) |
 | SSEUser | 15% | Opens SSE connections, holds 10-60s, mix of graceful/ungraceful disconnects |
-| AdminUser | 20% | Admin dashboard, daemon status, queue, config, logs |
+| AdminUser | 20% | Admin dashboard, daemon status, entity index status, config, logs |
 | HealthMonitor | 5% | Polls /health/live and /health/ready, tracks status transitions |
 
 ## Success Criteria
@@ -1812,12 +1784,12 @@ Environment variables:
 
 ```bash
 git add stress/
-git commit -m "feat: add locust load test suite"
+git commit -m "feat: add locust load test suite with LoadTestShape phases"
 ```
 
 ---
 
-### Task 13: Update deploy docs with Caddy health check
+### Task 14: Update deploy docs with Caddy health check
 
 **Files:**
 - Modify: `deploy/README.md:56-68`
@@ -1864,7 +1836,7 @@ git commit -m "docs: add health check config for Caddy and monitoring"
 
 ---
 
-### Task 14: Run all tests and verify
+### Task 15: Run all tests and verify
 
 **Files:** None (verification only)
 
@@ -1903,23 +1875,25 @@ Task 3 (config fields) ──┤
                           ├── Task 4 (health router) ── Task 5 (log filter)
 Task 6 (pyproject.toml) ──┘
                                │
+                          Task 9 (shared fixtures)
+                               │
                     ┌──────────┼──────────┐──────────┐
                     ▼          ▼          ▼          ▼
-              Task 7      Task 8      Task 9     Task 10
+              Task 7      Task 8     Task 10     Task 11
             (db pool)     (sse)    (threadpool)  (deadlock)
                     │          │          │          │
                     └──────────┼──────────┘──────────┘
                                ▼
-                          Task 11 (mixed)
+                          Task 12 (mixed)
                                │
                                ▼
-                          Task 12 (locust)
+                          Task 13 (locust)
                                │
                                ▼
-                          Task 13 (deploy docs)
+                          Task 14 (deploy docs)
                                │
                                ▼
-                          Task 14 (verify all)
+                          Task 15 (verify all)
 ```
 
-Tasks 1, 2, 3, 6 can run in parallel. Tasks 7–10 can run in parallel after Task 4. Task 12 is independent of 7–11.
+Tasks 1, 2, 3, 6 can run in parallel. Task 9 (shared fixtures) after Task 4. Tasks 7, 8, 10, 11 can run in parallel after Task 9. Task 13 is independent of 7–12.

--- a/docs/superpowers/plans/2026-04-01-stress-test-suite.md
+++ b/docs/superpowers/plans/2026-04-01-stress-test-suite.md
@@ -1,0 +1,1925 @@
+# Stress Test Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a comprehensive stress test suite to verify TEREDACTA's stability under load, including a health endpoint for monitoring.
+
+**Architecture:** Health endpoint (`/health/live` and `/health/ready`) built into the app with public pool/SSE metrics. Pytest stress tests for CI-runnable regression checks targeting specific failure modes (DB pool contention, SSE saturation, thread pool exhaustion, compound deadlock). Locust load tests for realistic sustained load against a live server.
+
+**Tech Stack:** FastAPI, pytest, pytest-timeout, httpx (async client), locust, sseclient-py
+
+**Spec:** `docs/superpowers/specs/2026-04-01-stress-test-suite-design.md`
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|---|---|
+| `teredacta/routers/health.py` | `/health/live` and `/health/ready` endpoints |
+| `teredacta/tests/test_health.py` | Health endpoint unit tests |
+| `teredacta/tests/test_stress_db_pool.py` | DB pool contention stress tests |
+| `teredacta/tests/test_stress_sse.py` | SSE saturation stress tests |
+| `teredacta/tests/test_stress_thread_pool.py` | Thread pool exhaustion stress tests |
+| `teredacta/tests/test_stress_compound_deadlock.py` | Production failure mode reproduction |
+| `teredacta/tests/test_stress_mixed.py` | Combined workload stress tests |
+| `stress/locustfile.py` | Locust user classes and load test scenarios |
+| `stress/config.py` | Locust configuration (target URL, credentials, thresholds) |
+| `stress/README.md` | How to run stress tests locally and against VPS |
+
+### Modified Files
+| File | Change |
+|---|---|
+| `teredacta/db_pool.py` | Add `pool_status()` method returning `{"idle": N, "in_use": N, "capacity": N}` |
+| `teredacta/unob.py` | Add public `pool_status()` method delegating to `ConnectionPool` |
+| `teredacta/sse.py` | Add `subscriber_count` property |
+| `teredacta/app.py` | Mount health router, record startup time, add log filter |
+| `teredacta/config.py` | Add `health_pool_degraded_threshold` and `health_sse_degraded_threshold` fields |
+| `pyproject.toml` | Add `stress` optional deps, `pytest-timeout` to dev deps, pytest markers config |
+| `deploy/README.md` | Add Caddy health check config |
+
+---
+
+### Task 1: Add pool_status() to ConnectionPool and UnobInterface
+
+**Files:**
+- Modify: `teredacta/db_pool.py:10-31`
+- Modify: `teredacta/unob.py:89-139`
+- Test: `teredacta/tests/test_health.py` (created in Task 2)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `teredacta/tests/test_health.py`:
+
+```python
+"""Tests for health endpoint and pool_status."""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from teredacta.db_pool import ConnectionPool
+
+
+class TestPoolStatus:
+    def test_pool_status_empty_pool(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 0, "capacity": 4}
+        pool.close()
+
+    def test_pool_status_one_acquired(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        conn = pool.acquire()
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 1, "capacity": 4}
+        pool.release(conn)
+        pool.close()
+
+    def test_pool_status_acquire_and_release(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        conn = pool.acquire()
+        pool.release(conn)
+        status = pool.pool_status()
+        assert status == {"idle": 1, "in_use": 0, "capacity": 4}
+        pool.close()
+
+    def test_pool_status_fully_acquired(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=2)
+        c1 = pool.acquire()
+        c2 = pool.acquire()
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 2, "capacity": 2}
+        pool.release(c1)
+        pool.release(c2)
+        pool.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest teredacta/tests/test_health.py::TestPoolStatus -v`
+Expected: FAIL with `AttributeError: 'ConnectionPool' object has no attribute 'pool_status'`
+
+- [ ] **Step 3: Implement pool_status() on ConnectionPool**
+
+Add to `teredacta/db_pool.py` after the `close()` method (after line 89):
+
+```python
+    def pool_status(self) -> dict:
+        """Return pool metrics without acquiring a connection.
+
+        Reads _size and _pool.qsize() which are approximate under
+        contention (CPython GIL makes individual reads atomic, but the
+        pair is not a snapshot). Acceptable for health monitoring.
+        """
+        idle = self._pool.qsize()
+        size = self._size
+        return {"idle": idle, "in_use": size - idle, "capacity": self._max_size}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest teredacta/tests/test_health.py::TestPoolStatus -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Add pool_status() to UnobInterface**
+
+Add to `teredacta/unob.py` after `_release_db` method (find `def _release_db` and add after that method):
+
+```python
+    def pool_status(self) -> dict | None:
+        """Return DB pool metrics, or None if pool not yet initialized."""
+        if self._pool is None:
+            return None
+        return self._pool.pool_status()
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add teredacta/db_pool.py teredacta/unob.py teredacta/tests/test_health.py
+git commit -m "feat: add pool_status() to ConnectionPool and UnobInterface"
+```
+
+---
+
+### Task 2: Add subscriber_count to SSEManager
+
+**Files:**
+- Modify: `teredacta/sse.py:11-17`
+- Test: `teredacta/tests/test_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `teredacta/tests/test_health.py`:
+
+```python
+import asyncio
+from teredacta.sse import SSEManager
+
+
+class TestSSESubscriberCount:
+    def test_subscriber_count_zero(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        assert sse.subscriber_count == 0
+
+    def test_subscriber_count_after_subscribe(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        q = sse.subscribe()
+        assert sse.subscriber_count == 1
+        sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    def test_subscriber_count_multiple(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        q1 = sse.subscribe()
+        q2 = sse.subscribe()
+        assert sse.subscriber_count == 2
+        sse.unsubscribe(q1)
+        assert sse.subscriber_count == 1
+        sse.unsubscribe(q2)
+        assert sse.subscriber_count == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest teredacta/tests/test_health.py::TestSSESubscriberCount -v`
+Expected: FAIL with `AttributeError: 'SSEManager' object has no attribute 'subscriber_count'`
+
+- [ ] **Step 3: Implement subscriber_count property on SSEManager**
+
+Add to `teredacta/sse.py` after `__init__` (after line 17):
+
+```python
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest teredacta/tests/test_health.py::TestSSESubscriberCount -v`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add teredacta/sse.py teredacta/tests/test_health.py
+git commit -m "feat: add subscriber_count property to SSEManager"
+```
+
+---
+
+### Task 3: Add health config fields
+
+**Files:**
+- Modify: `teredacta/config.py:14-33`
+- Test: `teredacta/tests/test_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `teredacta/tests/test_health.py`:
+
+```python
+from teredacta.config import TeredactaConfig
+
+
+class TestHealthConfig:
+    def test_default_health_thresholds(self):
+        cfg = TeredactaConfig()
+        assert cfg.health_pool_degraded_threshold == 3
+        assert cfg.health_sse_degraded_threshold == 20
+
+    def test_custom_health_thresholds(self):
+        cfg = TeredactaConfig(
+            health_pool_degraded_threshold=5,
+            health_sse_degraded_threshold=50,
+        )
+        assert cfg.health_pool_degraded_threshold == 5
+        assert cfg.health_sse_degraded_threshold == 50
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest teredacta/tests/test_health.py::TestHealthConfig -v`
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'health_pool_degraded_threshold'`
+
+- [ ] **Step 3: Add config fields**
+
+Add to `teredacta/config.py` in the `TeredactaConfig` dataclass, after `subprocess_timeout_seconds` (line 29):
+
+```python
+    health_pool_degraded_threshold: int = 3  # idle+uncreated <= this = degraded
+    health_sse_degraded_threshold: int = 20  # subscribers >= this = degraded
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest teredacta/tests/test_health.py::TestHealthConfig -v`
+Expected: All 2 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add teredacta/config.py teredacta/tests/test_health.py
+git commit -m "feat: add health threshold config fields"
+```
+
+---
+
+### Task 4: Implement health router
+
+**Files:**
+- Create: `teredacta/routers/health.py`
+- Modify: `teredacta/app.py:48-66`
+- Test: `teredacta/tests/test_health.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `teredacta/tests/test_health.py`:
+
+```python
+from fastapi.testclient import TestClient
+
+
+class TestHealthEndpoints:
+    @pytest.fixture
+    def health_client(self, tmp_path):
+        """Create a test client with a real DB for health tests."""
+        db_path = tmp_path / "test.db"
+        sqlite3.connect(str(db_path)).close()
+
+        cfg = TeredactaConfig(
+            unobfuscator_path=str(tmp_path),
+            unobfuscator_bin="echo",
+            db_path=str(db_path),
+            pdf_cache_dir=str(tmp_path / "pdf_cache"),
+            output_dir=str(tmp_path / "output"),
+            log_path=str(tmp_path / "unobfuscator.log"),
+            host="127.0.0.1",
+            port=8000,
+        )
+        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
+        (tmp_path / "output").mkdir(exist_ok=True)
+        (tmp_path / "unobfuscator.log").touch()
+
+        from teredacta.app import create_app
+        app = create_app(cfg)
+        return TestClient(app)
+
+    def test_liveness_returns_ok(self, health_client):
+        resp = health_client.get("/health/live")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_readiness_healthy_before_any_queries(self, health_client):
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+
+    def test_readiness_includes_details_from_localhost(self, health_client):
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        # localhost gets full details
+        assert "checks" in data
+        assert "db_pool" in data["checks"]
+        assert "sse" in data["checks"]
+        assert "uptime_seconds" in data["checks"]
+        assert "worker_pid" in data
+
+    def test_readiness_pool_none_is_healthy(self, health_client):
+        # Before any DB query, pool is None — should be healthy
+        resp = health_client.get("/health/ready")
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["checks"]["db_pool"]["status"] == "ok"
+
+    def test_readiness_returns_503_when_unhealthy(self, health_client):
+        # Force unhealthy by exhausting the pool
+        app = health_client.app
+        unob = app.state.unob
+        # Trigger pool creation and exhaust it
+        conns = []
+        for _ in range(8):
+            conns.append(unob._get_db())
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 200  # 0 idle but pool just created, may still be "degraded" or "unhealthy"
+        data = resp.json()
+        assert data["checks"]["db_pool"]["idle"] == 0
+        assert data["checks"]["db_pool"]["in_use"] == 8
+        # Release
+        for c in conns:
+            unob._release_db(c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest teredacta/tests/test_health.py::TestHealthEndpoints -v`
+Expected: FAIL (404 — `/health/live` route does not exist)
+
+- [ ] **Step 3: Create the health router**
+
+Create `teredacta/routers/health.py`:
+
+```python
+"""Health check endpoints for liveness and readiness probes."""
+
+import asyncio
+import os
+import time
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+_startup_time = time.monotonic()
+
+
+@router.get("/live")
+async def liveness():
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness(request: Request):
+    try:
+        result = await asyncio.wait_for(_readiness_checks(request), timeout=1.0)
+        return result
+    except asyncio.TimeoutError:
+        return JSONResponse({"status": "unhealthy"}, status_code=503)
+
+
+async def _readiness_checks(request: Request) -> JSONResponse:
+    config = request.app.state.config
+    unob = request.app.state.unob
+    sse = getattr(request.app.state, "sse", None)
+    is_local = getattr(request.client, "host", None) in ("127.0.0.1", "localhost", "::1", "testclient")
+    is_admin = getattr(request.state, "is_admin", False)
+    show_details = is_local or is_admin
+
+    # DB pool check
+    pool_data = unob.pool_status()
+    if pool_data is None:
+        pool_check = {"status": "ok", "idle": 0, "in_use": 0, "capacity": 8}
+    else:
+        available = pool_data["idle"] + (pool_data["capacity"] - pool_data["in_use"] - pool_data["idle"])
+        if available >= config.health_pool_degraded_threshold:
+            pool_status = "ok"
+        elif available >= 1:
+            pool_status = "degraded"
+        else:
+            pool_status = "error"
+        pool_check = {"status": pool_status, **pool_data}
+
+    # SSE check
+    sub_count = sse.subscriber_count if sse else 0
+    sse_degraded = config.health_sse_degraded_threshold
+    sse_unhealthy = sse_degraded * 5  # 100 by default
+    if sub_count >= sse_unhealthy:
+        sse_status = "error"
+    elif sub_count >= sse_degraded:
+        sse_status = "degraded"
+    else:
+        sse_status = "ok"
+    sse_check = {"status": sse_status, "subscribers": sub_count}
+
+    # Overall status
+    statuses = [pool_check["status"], sse_check["status"]]
+    if "error" in statuses:
+        overall = "unhealthy"
+    elif "degraded" in statuses:
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    status_code = 503 if overall == "unhealthy" else 200
+
+    if show_details:
+        body = {
+            "status": overall,
+            "worker_pid": os.getpid(),
+            "checks": {
+                "db_pool": pool_check,
+                "sse": sse_check,
+                "uptime_seconds": round(time.monotonic() - _startup_time, 1),
+            },
+        }
+    else:
+        body = {"status": overall}
+
+    return JSONResponse(body, status_code=status_code)
+```
+
+- [ ] **Step 4: Mount health router in app.py**
+
+Add to `teredacta/app.py` after the existing router imports (after line 48), add the health router import and mount. In the import line, add `health` to the imports:
+
+Change the import line from:
+```python
+    from teredacta.routers import dashboard, documents, groups, recoveries, pdf, queue, summary, admin, explore, highlights, api
+```
+to:
+```python
+    from teredacta.routers import dashboard, documents, groups, recoveries, pdf, queue, summary, admin, explore, highlights, api, health
+```
+
+And add the mount after the SSE router mount (after line 51):
+```python
+    app.include_router(health.router, prefix="/health")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest teredacta/tests/test_health.py::TestHealthEndpoints -v`
+Expected: All 5 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add teredacta/routers/health.py teredacta/app.py teredacta/tests/test_health.py
+git commit -m "feat: add /health/live and /health/ready endpoints"
+```
+
+---
+
+### Task 5: Add Uvicorn access log filter for health endpoints
+
+**Files:**
+- Modify: `teredacta/app.py`
+- Test: Manual verification (log filter is Uvicorn-level, not easily unit-testable)
+
+- [ ] **Step 1: Add log filter to app.py**
+
+Add at the top of `teredacta/app.py` after existing imports (after line 8):
+
+```python
+class _HealthLogFilter(logging.Filter):
+    """Suppress access log entries for /health/* requests."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        if "/health/" in msg:
+            return False
+        return True
+```
+
+Add inside `create_app()`, before the middleware definition (before line 40):
+
+```python
+    logging.getLogger("uvicorn.access").addFilter(_HealthLogFilter())
+```
+
+- [ ] **Step 2: Run existing tests to verify nothing broke**
+
+Run: `pytest teredacta/tests/test_health.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/app.py
+git commit -m "feat: suppress health endpoint access log noise"
+```
+
+---
+
+### Task 6: Update pyproject.toml with dependencies and pytest config
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add stress optional deps and pytest-timeout**
+
+In `pyproject.toml`, change the `[project.optional-dependencies]` section from:
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "httpx>=0.25.0",
+]
+```
+to:
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.2.0",
+    "httpx>=0.25.0",
+]
+stress = [
+    "locust>=2.20.0",
+    "sseclient-py>=1.8.0",
+]
+```
+
+- [ ] **Step 2: Add pytest marker configuration**
+
+Append to `pyproject.toml`:
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "stress: stress tests (deselected by default, run with: pytest -m stress)",
+]
+addopts = "-m 'not stress'"
+asyncio_mode = "auto"
+```
+
+- [ ] **Step 3: Install updated deps**
+
+Run: `pip install -e ".[dev]"`
+
+- [ ] **Step 4: Run existing tests to verify config doesn't break them**
+
+Run: `pytest teredacta/tests/test_health.py -v`
+Expected: All tests PASS (stress-marked tests would be skipped if any existed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore: add stress test deps, pytest-timeout, and marker config"
+```
+
+---
+
+### Task 7: Stress test — DB pool contention
+
+**Files:**
+- Create: `teredacta/tests/test_stress_db_pool.py`
+
+- [ ] **Step 1: Write the stress tests**
+
+Create `teredacta/tests/test_stress_db_pool.py`:
+
+```python
+"""Stress tests for DB connection pool under contention."""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from teredacta.db_pool import ConnectionPool
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestDBPoolContention:
+    @pytest.fixture
+    def stress_db(self, tmp_path):
+        """Create a DB with enough data for non-trivial queries."""
+        db_path = tmp_path / "stress.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE documents ("
+            "id TEXT PRIMARY KEY, source TEXT, extracted_text TEXT, "
+            "text_processed BOOLEAN DEFAULT 0, pdf_processed BOOLEAN DEFAULT 0, "
+            "original_filename TEXT, page_count INTEGER, size_bytes INTEGER)"
+        )
+        # Insert 100k rows for meaningful query pressure
+        rows = [
+            (f"doc-{i}", f"source-{i % 10}", f"text content for document {i} " * 50,
+             i % 3 == 0, i % 5 == 0, f"file_{i}.pdf", (i % 20) + 1, (i % 1000) * 1024)
+            for i in range(100_000)
+        ]
+        conn.executemany(
+            "INSERT INTO documents VALUES (?, ?, ?, ?, ?, ?, ?, ?)", rows
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @pytest.fixture
+    def pool(self, stress_db):
+        p = ConnectionPool(str(stress_db), max_size=8, read_only=True)
+        yield p
+        p.close()
+
+    def test_50_threads_no_deadlock(self, pool, stress_db):
+        """50 threads compete for 8 connections — all must complete."""
+        results = []
+        errors = []
+
+        def worker(thread_id):
+            try:
+                conn = pool.acquire(timeout=10.0)
+                try:
+                    # Simulate a non-trivial query
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM documents WHERE extracted_text LIKE ?",
+                        (f"%document {thread_id % 100}%",),
+                    ).fetchone()
+                    results.append((thread_id, row[0]))
+                finally:
+                    pool.release(conn)
+            except TimeoutError:
+                results.append((thread_id, "timeout"))
+            except Exception as e:
+                errors.append((thread_id, str(e)))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        # All threads must have completed (not hung)
+        assert len(results) + len(errors) == 50, (
+            f"Only {len(results) + len(errors)}/50 threads completed"
+        )
+        assert not errors, f"Unexpected errors: {errors}"
+
+    def test_pool_recovers_after_burst(self, pool, stress_db):
+        """After a burst of contention, pool returns to normal."""
+        # Phase 1: burst — hold all connections for 1 second
+        held = []
+        for _ in range(8):
+            held.append(pool.acquire(timeout=5.0))
+
+        status_during = pool.pool_status()
+        assert status_during["idle"] == 0
+        assert status_during["in_use"] == 8
+
+        # Release all
+        for conn in held:
+            pool.release(conn)
+
+        # Phase 2: verify recovery
+        status_after = pool.pool_status()
+        assert status_after["idle"] == 8
+        assert status_after["in_use"] == 0
+
+        # New acquire should succeed instantly
+        conn = pool.acquire(timeout=1.0)
+        pool.release(conn)
+
+    def test_timeout_error_no_leak(self, pool, stress_db):
+        """TimeoutError on acquire does not leak connections."""
+        # Hold all 8
+        held = []
+        for _ in range(8):
+            held.append(pool.acquire(timeout=5.0))
+
+        # Short-timeout acquire should raise TimeoutError
+        with pytest.raises(TimeoutError):
+            pool.acquire(timeout=0.5)
+
+        # Pool status should still show 8 in use (not 9)
+        status = pool.pool_status()
+        assert status["in_use"] == 8
+        assert status["capacity"] == 8
+
+        for conn in held:
+            pool.release(conn)
+
+        # After release, all 8 should be idle
+        status = pool.pool_status()
+        assert status["idle"] == 8
+```
+
+- [ ] **Step 2: Run to verify tests pass (they test real behavior)**
+
+Run: `pytest -m stress teredacta/tests/test_stress_db_pool.py -v`
+Expected: All 3 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/test_stress_db_pool.py
+git commit -m "test: add DB pool contention stress tests"
+```
+
+---
+
+### Task 8: Stress test — SSE saturation
+
+**Files:**
+- Create: `teredacta/tests/test_stress_sse.py`
+
+- [ ] **Step 1: Write the stress tests**
+
+Create `teredacta/tests/test_stress_sse.py`:
+
+```python
+"""Stress tests for SSE connection saturation and cleanup."""
+
+import asyncio
+
+import pytest
+
+from teredacta.sse import SSEManager
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestSSESaturation:
+
+    def test_200_subscribers_no_leak(self):
+        """Open 200 subscribers, unsubscribe all, verify cleanup."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        queues = [sse.subscribe() for _ in range(200)]
+        assert sse.subscriber_count == 200
+
+        for q in queues:
+            sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    def test_ungraceful_disconnect_cleanup_via_queuefull(self):
+        """Abandoned queues are cleaned up when QueueFull is hit during broadcast."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+
+        # Subscribe 10 queues, then "abandon" 5 (never read from them)
+        active_queues = []
+        abandoned_queues = []
+        for i in range(10):
+            q = sse.subscribe()
+            if i < 5:
+                active_queues.append(q)
+            else:
+                abandoned_queues.append(q)
+
+        assert sse.subscriber_count == 10
+
+        # Fill abandoned queues to capacity (maxsize=100)
+        # Simulate broadcasts until QueueFull triggers cleanup
+        for i in range(101):
+            event = f"data: {{\"seq\": {i}}}\n\n"
+            dead = []
+            for q in list(sse._subscribers):
+                try:
+                    q.put_nowait(event)
+                except asyncio.QueueFull:
+                    dead.append(q)
+            for q in dead:
+                sse._subscribers.discard(q)
+            # Drain active queues to prevent them from filling
+            for q in active_queues:
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+
+        # Abandoned queues should have been evicted
+        assert sse.subscriber_count == 5
+
+        for q in active_queues:
+            sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    def test_rapid_connect_disconnect_cycle(self):
+        """1000 rapid subscribe/unsubscribe cycles with no resource leak."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+
+        for _ in range(1000):
+            q = sse.subscribe()
+            sse.unsubscribe(q)
+
+        assert sse.subscriber_count == 0
+
+    def test_subscribe_without_iterating_persists(self):
+        """A queue subscribed but never iterated persists until QueueFull.
+
+        This documents the known behavior: if subscribe() is called
+        but the StreamingResponse generator never starts, the queue
+        stays in _subscribers until broadcasts fill it to capacity.
+        """
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        orphan = sse.subscribe()
+
+        # The orphan queue exists
+        assert sse.subscriber_count == 1
+
+        # It won't be cleaned up until QueueFull (100 events)
+        for i in range(99):
+            try:
+                orphan.put_nowait(f"data: {i}\n\n")
+            except asyncio.QueueFull:
+                break
+
+        # Still there (not yet full — 1 from subscribe + 99 = 100)
+        assert sse.subscriber_count == 1
+
+        # One more triggers QueueFull during next broadcast
+        dead = []
+        try:
+            orphan.put_nowait("data: overflow\n\n")
+        except asyncio.QueueFull:
+            dead.append(orphan)
+        for q in dead:
+            sse._subscribers.discard(q)
+
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subscribe_unsubscribe(self):
+        """Concurrent async subscribe/unsubscribe is safe."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+
+        async def churn(n):
+            for _ in range(n):
+                q = sse.subscribe()
+                await asyncio.sleep(0)  # yield to other tasks
+                sse.unsubscribe(q)
+
+        await asyncio.gather(*[churn(100) for _ in range(10)])
+        assert sse.subscriber_count == 0
+```
+
+- [ ] **Step 2: Run to verify tests pass**
+
+Run: `pytest -m stress teredacta/tests/test_stress_sse.py -v`
+Expected: All 5 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/test_stress_sse.py
+git commit -m "test: add SSE saturation stress tests"
+```
+
+---
+
+### Task 9: Stress test — Thread pool exhaustion
+
+**Files:**
+- Create: `teredacta/tests/test_stress_thread_pool.py`
+
+- [ ] **Step 1: Write the stress tests**
+
+Create `teredacta/tests/test_stress_thread_pool.py`:
+
+```python
+"""Stress tests for thread pool exhaustion scenarios."""
+
+import asyncio
+import sqlite3
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import httpx
+
+from teredacta.config import TeredactaConfig
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestThreadPoolExhaustion:
+
+    @pytest.fixture
+    def stress_app(self, tmp_path):
+        """Create app with a small, pinned executor for deterministic tests."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, source TEXT, "
+            "extracted_text TEXT, text_processed BOOLEAN DEFAULT 0, "
+            "pdf_processed BOOLEAN DEFAULT 0, original_filename TEXT, "
+            "page_count INTEGER, size_bytes INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE match_groups (group_id INTEGER PRIMARY KEY, "
+            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE merge_results (group_id INTEGER PRIMARY KEY, "
+            "merged_text TEXT, recovered_count INTEGER DEFAULT 0, "
+            "previous_recovered_count INTEGER DEFAULT 0, total_redacted INTEGER DEFAULT 0, "
+            "source_doc_ids TEXT, created_at DATETIME, updated_at DATETIME, "
+            "output_generated BOOLEAN DEFAULT 0, recovered_segments TEXT, "
+            "soft_recovered_count INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE document_fingerprints (doc_id TEXT PRIMARY KEY, "
+            "minhash_sig BLOB, shingle_count INTEGER, created_at DATETIME)"
+        )
+        conn.execute(
+            "CREATE TABLE jobs (job_id INTEGER PRIMARY KEY, stage TEXT, "
+            "payload TEXT, priority INTEGER DEFAULT 0, status TEXT DEFAULT 'pending', "
+            "error TEXT, created_at DATETIME, updated_at DATETIME)"
+        )
+        conn.execute(
+            "CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE release_batches (batch_id TEXT PRIMARY KEY, "
+            "first_seen_at DATETIME, fully_indexed BOOLEAN DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE match_group_members (group_id INTEGER, doc_id TEXT, "
+            "similarity REAL, added_at DATETIME, PRIMARY KEY (group_id, doc_id))"
+        )
+        conn.close()
+
+        cfg = TeredactaConfig(
+            unobfuscator_path=str(tmp_path),
+            unobfuscator_bin="echo",
+            db_path=str(db_path),
+            pdf_cache_dir=str(tmp_path / "pdf_cache"),
+            output_dir=str(tmp_path / "output"),
+            log_path=str(tmp_path / "unobfuscator.log"),
+            host="127.0.0.1",
+            port=8000,
+        )
+        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
+        (tmp_path / "output").mkdir(exist_ok=True)
+        (tmp_path / "unobfuscator.log").touch()
+
+        from teredacta.app import create_app
+        return create_app(cfg)
+
+    @pytest.mark.asyncio
+    async def test_liveness_responds_when_executor_saturated(self, stress_app):
+        """Liveness probe works even when executor threads are all blocked."""
+        # Pin a small executor
+        small_executor = ThreadPoolExecutor(max_workers=4)
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(small_executor)
+
+        # Saturate the executor with blocking tasks
+        block_event = asyncio.Event()
+        futures = []
+        for _ in range(4):
+            fut = loop.run_in_executor(None, lambda: asyncio.run(block_event.wait()) if False else time.sleep(10))
+            futures.append(fut)
+
+        try:
+            # Give tasks a moment to claim all executor threads
+            await asyncio.sleep(0.5)
+
+            # Liveness should still respond (it's pure async, no executor)
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=stress_app),
+                base_url="http://testserver",
+            ) as client:
+                resp = await asyncio.wait_for(
+                    client.get("/health/live"),
+                    timeout=3.0,
+                )
+                assert resp.status_code == 200
+                assert resp.json()["status"] == "ok"
+        finally:
+            # Cancel blocking tasks
+            for fut in futures:
+                fut.cancel()
+            small_executor.shutdown(wait=False, cancel_futures=True)
+
+    @pytest.mark.asyncio
+    async def test_readiness_responds_when_executor_saturated(self, stress_app):
+        """Readiness probe works even when executor threads are all blocked."""
+        small_executor = ThreadPoolExecutor(max_workers=4)
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(small_executor)
+
+        futures = []
+        for _ in range(4):
+            fut = loop.run_in_executor(None, lambda: time.sleep(10))
+            futures.append(fut)
+
+        try:
+            await asyncio.sleep(0.5)
+
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=stress_app),
+                base_url="http://testserver",
+            ) as client:
+                resp = await asyncio.wait_for(
+                    client.get("/health/ready"),
+                    timeout=3.0,
+                )
+                assert resp.status_code == 200
+                # Pool not initialized yet, so healthy
+                assert resp.json()["status"] == "healthy"
+        finally:
+            for fut in futures:
+                fut.cancel()
+            small_executor.shutdown(wait=False, cancel_futures=True)
+```
+
+- [ ] **Step 2: Run to verify tests pass**
+
+Run: `pytest -m stress teredacta/tests/test_stress_thread_pool.py -v`
+Expected: All 2 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/test_stress_thread_pool.py
+git commit -m "test: add thread pool exhaustion stress tests"
+```
+
+---
+
+### Task 10: Stress test — Compound deadlock (production failure mode)
+
+**Files:**
+- Create: `teredacta/tests/test_stress_compound_deadlock.py`
+
+- [ ] **Step 1: Write the stress tests**
+
+Create `teredacta/tests/test_stress_compound_deadlock.py`:
+
+```python
+"""Stress test reproducing the production compound deadlock.
+
+The production hang was: all default executor threads blocked on
+pool.acquire() (30s timeout) while SSE poll and admin requests
+also need executor threads. This test verifies:
+1. The event loop stays responsive during compound contention
+2. The system recovers after holds are released
+"""
+
+import asyncio
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import httpx
+
+from teredacta.config import TeredactaConfig
+from teredacta.db_pool import ConnectionPool
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestCompoundDeadlock:
+
+    @pytest.fixture
+    def stress_setup(self, tmp_path):
+        """Create app and pool with small sizes for deterministic testing."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE documents (id TEXT PRIMARY KEY, source TEXT, "
+            "extracted_text TEXT, text_processed BOOLEAN DEFAULT 0, "
+            "pdf_processed BOOLEAN DEFAULT 0, original_filename TEXT, "
+            "page_count INTEGER, size_bytes INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE match_groups (group_id INTEGER PRIMARY KEY, "
+            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE merge_results (group_id INTEGER PRIMARY KEY, "
+            "merged_text TEXT, recovered_count INTEGER DEFAULT 0, "
+            "previous_recovered_count INTEGER DEFAULT 0, total_redacted INTEGER DEFAULT 0, "
+            "source_doc_ids TEXT, created_at DATETIME, updated_at DATETIME, "
+            "output_generated BOOLEAN DEFAULT 0, recovered_segments TEXT, "
+            "soft_recovered_count INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE document_fingerprints (doc_id TEXT PRIMARY KEY, "
+            "minhash_sig BLOB, shingle_count INTEGER, created_at DATETIME)"
+        )
+        conn.execute(
+            "CREATE TABLE jobs (job_id INTEGER PRIMARY KEY, stage TEXT, "
+            "payload TEXT, priority INTEGER DEFAULT 0, status TEXT DEFAULT 'pending', "
+            "error TEXT, created_at DATETIME, updated_at DATETIME)"
+        )
+        conn.execute(
+            "CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE release_batches (batch_id TEXT PRIMARY KEY, "
+            "first_seen_at DATETIME, fully_indexed BOOLEAN DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE match_group_members (group_id INTEGER, doc_id TEXT, "
+            "similarity REAL, added_at DATETIME, PRIMARY KEY (group_id, doc_id))"
+        )
+        conn.close()
+
+        cfg = TeredactaConfig(
+            unobfuscator_path=str(tmp_path),
+            unobfuscator_bin="echo",
+            db_path=str(db_path),
+            pdf_cache_dir=str(tmp_path / "pdf_cache"),
+            output_dir=str(tmp_path / "output"),
+            log_path=str(tmp_path / "unobfuscator.log"),
+            host="127.0.0.1",
+            port=8000,
+        )
+        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
+        (tmp_path / "output").mkdir(exist_ok=True)
+        (tmp_path / "unobfuscator.log").touch()
+
+        from teredacta.app import create_app
+        app = create_app(cfg)
+        return app, db_path
+
+    @pytest.mark.asyncio
+    async def test_event_loop_survives_compound_deadlock(self, stress_setup):
+        """Event loop stays responsive even when executor + pool are both saturated."""
+        app, db_path = stress_setup
+
+        # Pin executor to 8 threads (same as pool size — worst case)
+        small_executor = ThreadPoolExecutor(max_workers=8)
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(small_executor)
+
+        # Create a pool we can control
+        pool = ConnectionPool(str(db_path), max_size=8, read_only=True)
+
+        # Phase 1: Hold all 8 pool connections
+        held_conns = [pool.acquire(timeout=5.0) for _ in range(8)]
+        assert pool.pool_status()["in_use"] == 8
+
+        # Phase 2: Saturate executor with tasks trying to acquire pool connections
+        # These will all block for up to 2 seconds waiting for a connection
+        blocked_futures = []
+        for _ in range(8):
+            fut = loop.run_in_executor(
+                None,
+                lambda: pool.acquire(timeout=2.0),
+            )
+            blocked_futures.append(fut)
+
+        # Give executor threads time to start blocking
+        await asyncio.sleep(0.5)
+
+        # Phase 3: Verify event loop is still alive
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await asyncio.wait_for(
+                client.get("/health/live"),
+                timeout=2.0,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+
+        # Phase 4: Release all held connections
+        for conn in held_conns:
+            pool.release(conn)
+
+        # Phase 5: Wait for blocked futures to resolve
+        results = await asyncio.gather(*blocked_futures, return_exceptions=True)
+
+        # Some may have acquired (after release), some may have timed out
+        acquired = [r for r in results if not isinstance(r, Exception)]
+        timed_out = [r for r in results if isinstance(r, (TimeoutError, Exception))]
+
+        # Release any that acquired
+        for conn in acquired:
+            pool.release(conn)
+
+        # Phase 6: Verify recovery
+        status = pool.pool_status()
+        assert status["in_use"] == 0
+        assert status["idle"] == 8  # all returned
+
+        # New acquire should work instantly
+        conn = pool.acquire(timeout=1.0)
+        pool.release(conn)
+
+        pool.close()
+        small_executor.shutdown(wait=False, cancel_futures=True)
+
+    @pytest.mark.asyncio
+    async def test_health_reports_degraded_during_contention(self, stress_setup):
+        """Health endpoint reports correct status during compound contention."""
+        app, db_path = stress_setup
+        unob = app.state.unob
+
+        # Force pool creation by making a query
+        conn = unob._get_db()
+        unob._release_db(conn)
+
+        # Hold all but 1 connection
+        held = []
+        for _ in range(7):
+            held.append(unob._get_db())
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            # Only 1 idle — should be degraded (threshold is 3)
+            assert data["status"] == "degraded"
+            assert data["checks"]["db_pool"]["idle"] == 1
+
+        for c in held:
+            unob._release_db(c)
+
+        # After release — should be healthy again
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            assert data["status"] == "healthy"
+```
+
+- [ ] **Step 2: Run to verify tests pass**
+
+Run: `pytest -m stress teredacta/tests/test_stress_compound_deadlock.py -v`
+Expected: All 2 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/test_stress_compound_deadlock.py
+git commit -m "test: add compound deadlock stress test (production failure mode)"
+```
+
+---
+
+### Task 11: Stress test — Mixed workload
+
+**Files:**
+- Create: `teredacta/tests/test_stress_mixed.py`
+
+- [ ] **Step 1: Write the stress tests**
+
+Create `teredacta/tests/test_stress_mixed.py`:
+
+```python
+"""Stress tests for mixed concurrent workloads."""
+
+import asyncio
+import sqlite3
+
+import pytest
+import httpx
+
+from teredacta.config import TeredactaConfig
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestMixedWorkload:
+
+    @pytest.fixture
+    def mixed_app(self, tmp_path):
+        """App with populated DB for mixed workload testing."""
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE documents (
+                id TEXT PRIMARY KEY, source TEXT, extracted_text TEXT,
+                text_processed BOOLEAN DEFAULT 0, pdf_processed BOOLEAN DEFAULT 0,
+                original_filename TEXT, page_count INTEGER, size_bytes INTEGER,
+                release_batch TEXT, description TEXT, pdf_url TEXT,
+                indexed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                text_source TEXT, ocr_processed BOOLEAN DEFAULT 0, page_tags TEXT
+            );
+            CREATE TABLE match_groups (
+                group_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP, merged BOOLEAN DEFAULT 0
+            );
+            CREATE TABLE match_group_members (
+                group_id INTEGER, doc_id TEXT, similarity REAL,
+                added_at DATETIME, PRIMARY KEY (group_id, doc_id)
+            );
+            CREATE TABLE merge_results (
+                group_id INTEGER PRIMARY KEY, merged_text TEXT,
+                recovered_count INTEGER DEFAULT 0, previous_recovered_count INTEGER DEFAULT 0,
+                total_redacted INTEGER DEFAULT 0, source_doc_ids TEXT,
+                created_at DATETIME, updated_at DATETIME,
+                output_generated BOOLEAN DEFAULT 0,
+                recovered_segments TEXT, soft_recovered_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE document_fingerprints (
+                doc_id TEXT PRIMARY KEY, minhash_sig BLOB,
+                shingle_count INTEGER, created_at DATETIME
+            );
+            CREATE TABLE jobs (
+                job_id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT,
+                payload TEXT, priority INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'pending', error TEXT,
+                created_at DATETIME, updated_at DATETIME
+            );
+            CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE release_batches (
+                batch_id TEXT PRIMARY KEY, first_seen_at DATETIME,
+                fully_indexed BOOLEAN DEFAULT 0
+            );
+        """)
+        # Seed with enough data for non-trivial queries
+        rows = [
+            (f"doc-{i}", f"source-{i % 5}", f"text content {i} " * 20,
+             1, 0, f"file_{i}.pdf", (i % 10) + 1, i * 100,
+             f"batch-{i % 3}", None, None, None, None, None)
+            for i in range(1000)
+        ]
+        conn.executemany(
+            "INSERT INTO documents VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", rows
+        )
+        conn.commit()
+        conn.close()
+
+        cfg = TeredactaConfig(
+            unobfuscator_path=str(tmp_path),
+            unobfuscator_bin="echo",
+            db_path=str(db_path),
+            pdf_cache_dir=str(tmp_path / "pdf_cache"),
+            output_dir=str(tmp_path / "output"),
+            log_path=str(tmp_path / "unobfuscator.log"),
+            host="127.0.0.1",
+            port=8000,
+        )
+        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
+        (tmp_path / "output").mkdir(exist_ok=True)
+        (tmp_path / "unobfuscator.log").touch()
+
+        from teredacta.app import create_app
+        return create_app(cfg)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_and_sse(self, mixed_app):
+        """Simultaneous HTTP requests + SSE subscribers don't deadlock."""
+        errors = []
+
+        async def make_requests(client, n):
+            for i in range(n):
+                try:
+                    resp = await client.get("/documents")
+                    if resp.status_code not in (200, 503):
+                        errors.append(f"GET /documents returned {resp.status_code}")
+                except Exception as e:
+                    errors.append(f"request error: {e}")
+
+        async def subscribe_sse(client):
+            """Subscribe to SSE briefly."""
+            try:
+                # Just hit the SSE endpoint — it'll 403 since no admin session,
+                # but the point is to exercise the request path
+                resp = await client.get("/sse/stats")
+                # 403 is expected (not admin)
+            except Exception:
+                pass
+
+        async def check_health(client, results):
+            for _ in range(5):
+                resp = await client.get("/health/ready")
+                results.append(resp.json())
+                await asyncio.sleep(0.2)
+
+        health_results = []
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=mixed_app),
+            base_url="http://testserver",
+        ) as client:
+            # Launch mixed workload
+            await asyncio.gather(
+                make_requests(client, 20),
+                make_requests(client, 20),
+                make_requests(client, 20),
+                subscribe_sse(client),
+                subscribe_sse(client),
+                check_health(client, health_results),
+            )
+
+        assert not errors, f"Errors during mixed workload: {errors}"
+        # Health should have been healthy throughout (light load)
+        for result in health_results:
+            assert result["status"] in ("healthy", "degraded")
+
+    @pytest.mark.asyncio
+    async def test_recovery_after_load(self, mixed_app):
+        """Health returns to healthy after load subsides."""
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=mixed_app),
+            base_url="http://testserver",
+        ) as client:
+            # Phase 1: Apply load
+            tasks = []
+            for _ in range(30):
+                tasks.append(client.get("/documents"))
+            await asyncio.gather(*tasks)
+
+            # Phase 2: Wait briefly for things to settle
+            await asyncio.sleep(0.5)
+
+            # Phase 3: Check health
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            assert data["status"] == "healthy"
+```
+
+- [ ] **Step 2: Run to verify tests pass**
+
+Run: `pytest -m stress teredacta/tests/test_stress_mixed.py -v`
+Expected: All 2 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add teredacta/tests/test_stress_mixed.py
+git commit -m "test: add mixed workload stress tests"
+```
+
+---
+
+### Task 12: Locust load test suite
+
+**Files:**
+- Create: `stress/config.py`
+- Create: `stress/locustfile.py`
+- Create: `stress/README.md`
+
+- [ ] **Step 1: Create stress/config.py**
+
+```bash
+mkdir -p stress
+```
+
+Create `stress/config.py`:
+
+```python
+"""Configuration for locust stress tests."""
+
+import os
+
+# Target server
+TARGET_HOST = os.environ.get("STRESS_TARGET_HOST", "http://localhost:8000")
+
+# Admin credentials for SSE and admin endpoints
+ADMIN_PASSWORD = os.environ.get("STRESS_ADMIN_PASSWORD", "test-password")
+
+# User class weights (must sum to 100)
+WEB_USER_WEIGHT = 60
+SSE_USER_WEIGHT = 15
+ADMIN_USER_WEIGHT = 20
+HEALTH_MONITOR_WEIGHT = 5
+
+# Health monitoring thresholds
+LIVENESS_FAILURE_SECONDS = 0  # Any liveness failure is critical
+READINESS_UNHEALTHY_SECONDS = 60  # Sustained unhealthy = test failure
+
+# SSE connection parameters
+SSE_MIN_HOLD_SECONDS = 10
+SSE_MAX_HOLD_SECONDS = 60
+```
+
+- [ ] **Step 2: Create stress/locustfile.py**
+
+Create `stress/locustfile.py`:
+
+```python
+"""Locust stress test suite for TEREDACTA.
+
+Run headless:
+    locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
+
+Run with Web UI:
+    locust -f stress/locustfile.py --host http://localhost:8000
+"""
+
+import logging
+import random
+import time
+
+from locust import HttpUser, between, events, task
+from locust.exception import StopUser
+
+from config import (
+    ADMIN_PASSWORD,
+    ADMIN_USER_WEIGHT,
+    HEALTH_MONITOR_WEIGHT,
+    READINESS_UNHEALTHY_SECONDS,
+    SSE_MAX_HOLD_SECONDS,
+    SSE_MIN_HOLD_SECONDS,
+    SSE_USER_WEIGHT,
+    WEB_USER_WEIGHT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Track health status transitions globally
+_health_tracker = {
+    "last_healthy": time.monotonic(),
+    "unhealthy_since": None,
+    "liveness_failures": 0,
+}
+
+
+class WebUser(HttpUser):
+    """Simulates a visitor browsing public pages."""
+
+    weight = WEB_USER_WEIGHT
+    wait_time = between(1, 5)
+
+    @task(5)
+    def browse_documents(self):
+        page = random.randint(1, 10)
+        self.client.get(f"/documents?page={page}", name="/documents?page=[N]")
+
+    @task(3)
+    def browse_recoveries(self):
+        self.client.get("/recoveries")
+
+    @task(3)
+    def browse_highlights(self):
+        self.client.get("/highlights")
+
+    @task(2)
+    def browse_explore(self):
+        self.client.get("/")
+
+    @task(1)
+    def view_document_detail(self):
+        # Try a document ID — may 404 if data is sparse, that's fine
+        doc_id = f"doc-{random.randint(1, 100)}"
+        self.client.get(f"/documents/{doc_id}", name="/documents/[id]")
+
+
+class SSEUser(HttpUser):
+    """Simulates an admin subscribing to SSE stats."""
+
+    weight = SSE_USER_WEIGHT
+    wait_time = between(SSE_MIN_HOLD_SECONDS, SSE_MAX_HOLD_SECONDS)
+
+    def on_start(self):
+        """Authenticate to get admin session cookie."""
+        self.client.post(
+            "/admin/login",
+            data={"password": ADMIN_PASSWORD},
+            name="/admin/login",
+        )
+
+    @task
+    def subscribe_sse(self):
+        """Open SSE connection, hold it, then disconnect."""
+        hold_time = random.uniform(SSE_MIN_HOLD_SECONDS, SSE_MAX_HOLD_SECONDS)
+        start = time.monotonic()
+
+        try:
+            with self.client.get(
+                "/sse/stats",
+                stream=True,
+                name="/sse/stats",
+                catch_response=True,
+            ) as resp:
+                if resp.status_code == 403:
+                    resp.failure("Not authenticated — SSE returned 403")
+                    return
+                resp.success()
+
+                # Hold connection for the specified duration
+                for line in resp.iter_lines():
+                    if time.monotonic() - start > hold_time:
+                        break
+        except Exception as e:
+            logger.debug("SSE connection ended: %s", e)
+
+        # Occasionally simulate ungraceful disconnect (just stop — no close)
+        if random.random() < 0.3:
+            return  # ungraceful: let connection be GC'd
+
+
+class AdminUser(HttpUser):
+    """Simulates admin dashboard usage."""
+
+    weight = ADMIN_USER_WEIGHT
+    wait_time = between(2, 8)
+
+    def on_start(self):
+        self.client.post(
+            "/admin/login",
+            data={"password": ADMIN_PASSWORD},
+            name="/admin/login",
+        )
+
+    @task(3)
+    def view_admin_dashboard(self):
+        self.client.get("/admin/")
+
+    @task(2)
+    def check_daemon_status(self):
+        self.client.get("/admin/daemon/status")
+
+    @task(2)
+    def view_queue(self):
+        self.client.get("/admin/queue")
+
+    @task(1)
+    def view_config(self):
+        self.client.get("/admin/config")
+
+    @task(1)
+    def view_logs(self):
+        self.client.get("/admin/logs")
+
+
+class HealthMonitor(HttpUser):
+    """Continuously monitors health endpoints."""
+
+    weight = HEALTH_MONITOR_WEIGHT
+    wait_time = between(2, 5)
+
+    @task(3)
+    def check_liveness(self):
+        with self.client.get("/health/live", catch_response=True, name="/health/live") as resp:
+            if resp.status_code != 200:
+                _health_tracker["liveness_failures"] += 1
+                resp.failure(f"LIVENESS FAILURE: {resp.status_code}")
+                logger.error("LIVENESS PROBE FAILED: status=%s", resp.status_code)
+            else:
+                resp.success()
+
+    @task(1)
+    def check_readiness(self):
+        with self.client.get("/health/ready", catch_response=True, name="/health/ready") as resp:
+            now = time.monotonic()
+
+            if resp.status_code == 200:
+                data = resp.json()
+                status = data.get("status", "unknown")
+
+                if status == "healthy":
+                    _health_tracker["last_healthy"] = now
+                    _health_tracker["unhealthy_since"] = None
+                    resp.success()
+                elif status == "degraded":
+                    # Expected under load — log but don't fail
+                    resp.success()
+                    logger.info("Health: degraded")
+                else:
+                    resp.failure(f"Unexpected status: {status}")
+            elif resp.status_code == 503:
+                if _health_tracker["unhealthy_since"] is None:
+                    _health_tracker["unhealthy_since"] = now
+                    logger.warning("Health: unhealthy (started)")
+
+                duration = now - _health_tracker["unhealthy_since"]
+                if duration > READINESS_UNHEALTHY_SECONDS:
+                    resp.failure(
+                        f"UNHEALTHY for {duration:.0f}s (threshold: {READINESS_UNHEALTHY_SECONDS}s)"
+                    )
+                else:
+                    resp.success()
+            else:
+                resp.failure(f"Unexpected status code: {resp.status_code}")
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    """Report health summary at end of test."""
+    tracker = _health_tracker
+    logger.info("=== Health Summary ===")
+    logger.info("Liveness failures: %d", tracker["liveness_failures"])
+    if tracker["unhealthy_since"]:
+        logger.warning("Server was unhealthy at test end")
+    else:
+        logger.info("Server was healthy at test end")
+
+    if tracker["liveness_failures"] > 0:
+        logger.error("TEST FAILED: Liveness probe failures detected")
+        environment.process_exit_code = 1
+```
+
+- [ ] **Step 3: Create stress/README.md**
+
+Create `stress/README.md`:
+
+```markdown
+# TEREDACTA Stress Tests
+
+Load testing suite using [Locust](https://locust.io/).
+
+## Setup
+
+```bash
+pip install -e ".[stress]"
+```
+
+## Running
+
+### Against local server
+
+Start TEREDACTA locally first:
+```bash
+teredacta run
+```
+
+Then run the stress tests:
+```bash
+# Headless (CI mode)
+locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
+
+# With web UI (interactive)
+locust -f stress/locustfile.py --host http://localhost:8000
+# Then open http://localhost:8089
+```
+
+### Against VPS
+
+```bash
+export STRESS_ADMIN_PASSWORD=your-admin-password
+locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host https://your-vps.example.com
+```
+
+### With web UI
+
+```bash
+locust -f stress/locustfile.py --host https://your-vps.example.com
+```
+Open http://localhost:8089 to configure users, spawn rate, and watch results.
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `STRESS_TARGET_HOST` | `http://localhost:8000` | Target server URL |
+| `STRESS_ADMIN_PASSWORD` | `test-password` | Admin password for SSE/admin tests |
+
+## User Profiles
+
+| Profile | Weight | Description |
+|---|---|---|
+| WebUser | 60% | Browses public pages (documents, recoveries, highlights) |
+| SSEUser | 15% | Opens SSE connections, holds 10-60s, mix of graceful/ungraceful disconnects |
+| AdminUser | 20% | Admin dashboard, daemon status, queue, config, logs |
+| HealthMonitor | 5% | Polls /health/live and /health/ready, tracks status transitions |
+
+## Success Criteria
+
+- Liveness probe (`/health/live`) never fails
+- Readiness probe (`/health/ready`) does not report "unhealthy" for more than 60 seconds continuously
+- No HTTP 500 errors
+- Server recovers to "healthy" after load subsides
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stress/
+git commit -m "feat: add locust load test suite"
+```
+
+---
+
+### Task 13: Update deploy docs with Caddy health check
+
+**Files:**
+- Modify: `deploy/README.md:56-68`
+
+- [ ] **Step 1: Add Caddy health check config**
+
+In `deploy/README.md`, change the recommended production config section. After the existing content at the end of the file, add:
+
+```markdown
+
+## Health Checks
+
+TEREDACTA exposes health endpoints for monitoring:
+
+- `GET /health/live` — Liveness probe (event loop alive?)
+- `GET /health/ready` — Readiness probe (DB pool, SSE status)
+
+### Caddy Health Check
+
+Add to your Caddyfile reverse_proxy block:
+
+```
+reverse_proxy localhost:8000 {
+    health_uri /health/live
+    health_interval 5s
+}
+```
+
+This lets Caddy detect and route around unresponsive workers.
+
+### External Monitoring
+
+Point your monitoring tool (UptimeRobot, Healthchecks.io, etc.) at:
+- Liveness: `https://your-domain.com/health/live`
+- Readiness: `https://your-domain.com/health/ready`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/README.md
+git commit -m "docs: add health check config for Caddy and monitoring"
+```
+
+---
+
+### Task 14: Run all tests and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run existing unit tests (non-stress)**
+
+Run: `pytest teredacta/tests/ -v`
+Expected: All existing tests PASS, stress tests are DESELECTED
+
+- [ ] **Step 2: Run health endpoint tests**
+
+Run: `pytest teredacta/tests/test_health.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run stress tests**
+
+Run: `pytest -m stress -v`
+Expected: All stress tests PASS
+
+- [ ] **Step 4: Verify stress tests are excluded from default run**
+
+Run: `pytest teredacta/tests/ --co -q | grep stress`
+Expected: No stress test files listed (deselected by marker)
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+Only if previous steps required fixes.
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (pool_status) ──┐
+Task 2 (subscriber_count) ──┤
+Task 3 (config fields) ──┤
+                          ├── Task 4 (health router) ── Task 5 (log filter)
+Task 6 (pyproject.toml) ──┘
+                               │
+                    ┌──────────┼──────────┐──────────┐
+                    ▼          ▼          ▼          ▼
+              Task 7      Task 8      Task 9     Task 10
+            (db pool)     (sse)    (threadpool)  (deadlock)
+                    │          │          │          │
+                    └──────────┼──────────┘──────────┘
+                               ▼
+                          Task 11 (mixed)
+                               │
+                               ▼
+                          Task 12 (locust)
+                               │
+                               ▼
+                          Task 13 (deploy docs)
+                               │
+                               ▼
+                          Task 14 (verify all)
+```
+
+Tasks 1, 2, 3, 6 can run in parallel. Tasks 7–10 can run in parallel after Task 4. Task 12 is independent of 7–11.

--- a/docs/superpowers/specs/2026-04-01-stress-test-suite-design.md
+++ b/docs/superpowers/specs/2026-04-01-stress-test-suite-design.md
@@ -10,54 +10,96 @@ Comprehensive stress test suite to verify TEREDACTA's stability under load, targ
 
 ## Architecture: Approach C (Locust + Pytest Stress Tests)
 
-- **Pytest stress tests** — fast, deterministic, CI-runnable. Target specific failure modes: DB pool contention, SSE saturation, thread pool exhaustion, mixed workloads.
+- **Pytest stress tests** — fast, deterministic, CI-runnable. Target specific failure modes: DB pool contention, SSE saturation, thread pool exhaustion, compound deadlock, mixed workloads.
 - **Locust load tests** — realistic sustained load with composable user profiles. Run manually against localhost (fixture mode) or live VPS.
 
 ## 1. Health Endpoint
 
-Two new public async endpoints, no authentication required.
+Two new async endpoints. Mounted via `app.include_router(health_router, prefix="/health")`.
 
 ### `GET /health/live` — Liveness Probe
 
-Returns `{"status": "ok"}` with HTTP 200. No dependency checks. Proves the event loop is not deadlocked.
+Returns `{"status": "ok"}` with HTTP 200. No dependency checks. Proves the event loop is not deadlocked. Pure async — no executor, no DB, no locks.
 
 ### `GET /health/ready` — Readiness Probe
 
-Returns JSON with component checks:
+Returns JSON with component checks. Detailed metrics are only included when the request comes from localhost or an authenticated admin session; public responses return only the top-level status string.
+
+**Authenticated/localhost response:**
 
 ```json
 {
   "status": "healthy | degraded | unhealthy",
+  "worker_pid": 12345,
   "checks": {
-    "db_pool": {"status": "ok | degraded | error", "available": 6, "max": 8},
-    "sse": {"status": "ok | degraded", "subscribers": 3},
+    "db_pool": {"status": "ok", "idle": 3, "in_use": 2, "capacity": 8},
+    "sse": {"status": "ok", "subscribers": 3},
     "uptime_seconds": 1234
   }
 }
 ```
 
+**Public response:**
+
+```json
+{
+  "status": "healthy | degraded | unhealthy"
+}
+```
+
+**Pool metrics — correct formula:**
+
+The pool uses lazy initialization (`_size` grows from 0 to `max_size`). The metrics are:
+- `idle` = `self._pool.qsize()` — connections sitting in the queue ready for use
+- `in_use` = `self._size - self._pool.qsize()` — connections checked out
+- `capacity` = `self._max_size` — maximum possible connections
+
+Note: `queue.Queue.qsize()` is approximate under contention (CPython). This is acceptable for health monitoring — the thresholds have enough margin that off-by-one races don't affect classification.
+
 **Thresholds (8-connection pool):**
 
 | Metric | Healthy | Degraded | Unhealthy |
 |---|---|---|---|
-| DB pool available | ≥3 | 1–2 | 0 or acquire timeout |
-| SSE subscribers | <100 | 100–500 | >500 |
+| DB pool idle + uncreated | ≥3 | 1–2 | 0 or pool is None and app has served requests |
+| SSE subscribers | <20 | 20–100 | >100 |
+
+SSE thresholds are deliberately low because `/sse/stats` is admin-only — even 20 concurrent admin SSE connections is suspicious for typical deployments (0–5 admin users). Thresholds are configurable via `TeredactaConfig` fields `health_pool_degraded_threshold` and `health_sse_degraded_threshold`.
 
 **Design constraints:**
-- Never acquires a DB pool connection — inspects pool queue metadata only
+- Never acquires a DB pool connection — reads pool metadata only
+- Never acquires `ConnectionPool._lock` — reads `_size` and `_pool.qsize()` which are safe under the GIL for approximate values
 - Async — does not occupy a thread pool slot
-- 3-second hard timeout via `asyncio.wait_for()` — returns 503 if checks hang
+- 1-second hard timeout via `asyncio.wait_for()` — returns 503 if checks hang (if reading two integers takes >1s, the process is effectively dead)
 - Returns HTTP 200 for healthy/degraded, HTTP 503 for unhealthy
 
-**Required change:** Expose `available_count` property on `ConnectionPool` so the health endpoint can inspect pool state without acquiring a connection.
+**Required changes:**
+1. Add public `pool_status() -> dict | None` method on `UnobInterface` that returns `{"idle": N, "in_use": N, "capacity": N}` or `None` if pool not yet initialized. The health endpoint treats `None` as "ok" (no queries have been made yet, pool not needed).
+2. Add `subscriber_count` property on `SSEManager` returning `len(self._subscribers)`.
+
+**Multi-worker note:** With `workers > 1`, each worker has its own pool and SSE manager. The `/health/ready` response reflects the state of the worker that handles the request. The `worker_pid` field (in authenticated responses) allows correlation. Caddy's round-robin means a single probe may not detect a hung worker — this is a known limitation. If one worker deadlocks, Caddy will still route some requests to it (resulting in timeouts), and probes will intermittently report healthy vs unhealthy depending on which worker responds.
+
+**Log suppression:** Add Uvicorn access log filter to suppress `/health/*` requests, preventing log noise from frequent polling (43k+ lines/day at 2-second intervals).
 
 ### Implementation
 
-New file: `teredacta/routers/health.py`, mounted in `app.py`.
+New file: `teredacta/routers/health.py`, mounted in `app.py` with `prefix="/health"`.
+
+### Caddy Integration
+
+Update `deploy/README.md` with health check config:
+
+```
+reverse_proxy localhost:8000 {
+    health_uri /health/live
+    health_interval 5s
+}
+```
 
 ## 2. Pytest Stress Tests
 
 CI-runnable regression tests targeting specific failure modes. Located in `teredacta/tests/`.
+
+All stress tests use `httpx.AsyncClient` with ASGI transport (not `TestClient`) to exercise the full async stack, including the real event loop, executor, and SSE generator lifecycle.
 
 ### `test_stress_db_pool.py` — DB Pool Contention
 
@@ -65,42 +107,84 @@ CI-runnable regression tests targeting specific failure modes. Located in `tered
 - Verify no deadlocks — all threads complete (with either a connection or a timeout error)
 - Verify pool recovers after burst subsides (connections returned, new acquires succeed)
 - Verify graceful timeout behavior (proper exception, not a hang)
+- Include variant with short acquire timeout (1–2s) to exercise the `TimeoutError` path and verify no connection leaks on timeout
 
 ### `test_stress_sse.py` — SSE Connection Saturation
 
 - Open 200+ SSE subscriber queues rapidly
 - Disconnect half ungracefully (abandon without unsubscribe)
-- Verify cleanup — dead queues are detected and removed
-- Verify remaining subscribers still receive events
+- Verify that abandoned queues persist until `QueueFull` eviction (this is the current behavior — the test documents it, not assumes cleanup)
+- Force `QueueFull` by broadcasting enough events, then verify eviction occurs
+- Verify remaining active subscribers still receive events
 - Rapid connect/disconnect cycling (1000 cycles) — verify no resource leak
+- Test the subscribe-before-StreamingResponse race: subscribe a queue, then never start iterating the generator — verify the queue is eventually cleaned up or document it as a known leak vector
 
 ### `test_stress_thread_pool.py` — Thread Pool Exhaustion
 
-- Submit blocking tasks that saturate the default executor
-- Verify the health endpoint still responds (async, not blocked by executor)
+- Pin executor size to a known value (e.g., 8 threads) for deterministic testing via `loop.set_default_executor(ThreadPoolExecutor(max_workers=8))`
+- Submit blocking tasks that saturate the pinned executor
+- Verify the liveness endpoint (`/health/live`) still responds (pure async, no executor dependency)
 - Verify SSE polling continues (also async)
 - Verify server returns errors (not hangs) when executor is full
+- Include a variant that goes through `run_in_executor` → `pool.acquire()` to exercise the real code path, not just direct `pool.acquire()`
+
+### `test_stress_compound_deadlock.py` — Production Failure Mode (NEW)
+
+This is the specific scenario that caused the production hang:
+1. Fill all 8 DB pool connections with long-running holds (simulated via sleep or deliberate slow queries)
+2. Submit enough `run_in_executor(None, pool.acquire)` calls to saturate the default executor — all executor threads now blocked waiting for pool connections
+3. Verify the event loop itself remains responsive (liveness probe returns 200)
+4. Verify that additional `run_in_executor` calls (e.g., from SSE poll, admin requests) fail or queue rather than deadlocking
+5. Release the long holds — verify the system recovers (pool connections returned, executor unblocks, health returns to healthy)
+6. Pin executor to a small size (e.g., 8 threads = same as pool size) to make the compound deadlock deterministic
 
 ### `test_stress_mixed.py` — Combined Workload
 
-- Simultaneously: HTTP requests to multiple endpoints + SSE subscribers + DB-heavy queries
+- Simultaneously: HTTP requests to multiple endpoints + SSE subscribers + DB-heavy queries via `run_in_executor`
+- Explicitly exercise cross-resource contention: N SSE subscribers holding executor slots while M requests also need executor slots for DB access
 - Verify health endpoint reports degraded (not unhealthy) under moderate load
 - Verify clean recovery after load stops — health returns to healthy
 
 ### `test_health.py` — Health Endpoint Unit Tests
 
-- Verify response format and status codes
+- Verify response format and status codes (authenticated vs public responses)
 - Verify threshold transitions (healthy → degraded → unhealthy)
-- Verify 3-second timeout behavior
+- Verify 1-second timeout behavior
 - Verify liveness probe works when readiness is unhealthy
+- Verify `pool_status()` returns `None` before first query and valid dict after
+- Verify `worker_pid` is included in authenticated responses
 
 ### Test Infrastructure
 
-- Synthetic SQLite DB with ~10k documents for non-trivial queries
-- Configurable concurrency levels via pytest parametrize or env vars
-- 30-second timeout on all stress tests (hangs fail as test failures, not infinite waits)
-- `@pytest.mark.stress` marker, excluded from default test runs via `pytest.ini`
-- Real SQLite and real connection pool — no mocks for stressed resources
+**Synthetic database:** SQLite DB with ~100k documents for meaningful query pressure. SQLite scans 10k rows in single-digit milliseconds — 100k with populated `extracted_text` fields (random 500–2000 character strings) creates actual I/O pressure. Include proportional related rows:
+- 100k `documents` with populated `extracted_text`, `original_filename`, varying `page_count`/`size_bytes`
+- 5k `match_groups` with 15k `match_group_members`
+- 3k `merge_results` with populated `merged_text` (1000+ chars)
+- 500 `jobs` across all statuses
+
+Use deliberately expensive queries where needed: `LIKE '%pattern%'` on `extracted_text` (forces full scan), self-joins, unindexed filters.
+
+**Pytest configuration in `pyproject.toml`:**
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "stress: stress tests (excluded from default runs)",
+]
+addopts = "-m 'not stress'"
+```
+
+Running stress tests explicitly: `pytest -m stress -v`
+
+**Timeouts:**
+- Per-operation timeout: 5 seconds (e.g., a single `pool.acquire()`)
+- Per-test timeout: 90 seconds (allows ramp-up, sustained load, recovery verification)
+- Enforced via `pytest-timeout>=2.2.0` (added to dev dependencies)
+
+**Executor pinning:** Stress tests that depend on executor saturation must pin the executor size to a known value (e.g., 8) at test setup. This ensures deterministic behavior across machines with different CPU counts (GitHub Actions: 2 vCPUs = 6 default threads; dev machine: 16 cores = 20 default threads).
+
+**CI notes:** Stress tests run on-demand (`pytest -m stress`), not in the default `pytest` invocation. CI can include them as a separate job if desired.
+
+Real SQLite and real connection pool — no mocks for stressed resources.
 
 ## 3. Locust Load Tests
 
@@ -108,48 +192,67 @@ Located in `stress/` at project root (separate from unit tests — requires a ru
 
 ### User Classes
 
-**`WebUser`** — Standard page browsing
+**`WebUser`** (weight: 60) — Standard page browsing
 - Hits `/`, `/documents`, `/recoveries`, `/highlights`, random document/recovery detail pages
 - Realistic think time (1–5s between requests)
 - Validates responses are 200, not 503 or timeouts
 
-**`SSEUser`** — SSE subscriber (custom User subclass)
-- Authenticates, opens SSE connection to `/sse/stats`
+**`SSEUser`** (weight: 15) — SSE subscriber (custom User subclass)
+- Auth flow: POST to `/admin/login` with configured credentials, capture session cookie, pass cookie in SSE connection headers
+- Opens SSE connection to `/sse/stats` using `sseclient-py` with the authenticated session
 - Holds connection for random duration (10–60s)
-- Mix of graceful and ungraceful disconnects
+- Mix of graceful disconnects (close connection) and ungraceful (kill greenlet mid-stream)
 - Tracks events received, connection duration, errors
+- Note: SSE connections block the gevent greenlet for their duration — the weight of 15% ensures ~30 of 200 users are SSE at peak, leaving 170 greenlets for HTTP load
 
-**`AdminUser`** — Admin operations
-- Authenticates, hits admin endpoints: daemon status, config page, queue, logs
-- Lower weight (fewer admin users than public users)
+**`AdminUser`** (weight: 20) — Admin operations
+- Authenticates via `/admin/login`, manages session cookie
+- Hits admin endpoints: daemon status, config page, queue, logs
+- Occasional write operations: save config, trigger search
 
-**`HealthMonitor`** — Continuous health polling
-- Hits `/health/ready` every 2 seconds throughout the run
-- Records status transitions (healthy → degraded → unhealthy)
-- Fails the run if unhealthy is sustained for >30 seconds
+**`HealthMonitor`** (weight: 5) — Continuous health polling
+- Hits `/health/live` every 2 seconds and `/health/ready` every 5 seconds
+- Distinguishes between failure modes:
+  - Liveness failure (any duration) = critical failure, flag immediately
+  - Readiness unhealthy (sustained >60 seconds) = test failure
+  - Readiness degraded = expected under load, log but don't fail
+- Records all status transitions with timestamps
 
 ### Configuration
 
-- `stress/config.py` — target URL, user counts, spawn rates, run duration
+- `stress/config.py` — target URL, credentials, user counts, spawn rates, run duration
 - Default: fixture mode (localhost:8000 with synthetic data)
 - `--host` flag for live VPS testing
-- Defaults: 50 users, spawn rate 5/s, 5-minute run
+- `STRESS_ADMIN_PASSWORD` env var for credentials
+- Defaults: **200 users**, spawn rate 10/s, 5-minute run
+
+**Load profile justification:** With 200 users and 1–5s think time (avg 3s), expected concurrent in-flight requests ≈ 200/3 × avg_response_time. Even at 100ms avg response time, that's ~7 concurrent requests. At 500ms (under load), ~33 concurrent. This is sufficient to saturate the 8-connection pool and stress the default executor (6–20 threads depending on machine). The VPS profile can be tuned higher.
+
+### Phases
+
+1. **Warm-up** (30s): Ramp from 0 to 200 users at 10/s
+2. **Sustained load** (4 minutes): Full user count, all profiles active
+3. **Cool-down** (30s): Ramp down to 0 users via custom `LoadTestShape`
+4. **Recovery verification**: HealthMonitor continues for 15s after cool-down, verifies health returns to "healthy"
 
 ### Running
 
 ```bash
-# Headless CI mode
-locust -f stress/locustfile.py --headless -u 50 -r 5 -t 5m --host http://localhost:8000
+# Headless against VPS
+locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host https://your-vps.example.com
 
-# Web UI for VPS testing
+# Web UI for interactive testing
 locust -f stress/locustfile.py --host https://your-vps.example.com
+
+# Local fixture mode
+locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
 ```
 
 ## 4. Dependencies & Project Structure
 
 ### New Dependencies
 
-In `pyproject.toml` under `[project.optional-dependencies]`:
+In `pyproject.toml`:
 
 ```toml
 [project.optional-dependencies]
@@ -157,20 +260,36 @@ stress = [
     "locust>=2.20.0",
     "sseclient-py>=1.8.0",
 ]
+
+# Add to existing dev deps:
+# pytest-timeout>=2.2.0
 ```
 
-No new core dependencies. Pytest stress tests use only stdlib + existing test deps.
+Pytest stress tests use stdlib + existing test deps + `pytest-timeout`. Locust tests additionally need the `stress` extra.
+
+### Pytest Configuration
+
+Add to `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+markers = [
+    "stress: stress tests (deselected by default, run with: pytest -m stress)",
+]
+addopts = "-m 'not stress'"
+```
 
 ### Project Structure Additions
 
 ```
 teredacta/
 ├── routers/
-│   └── health.py              # /health/live and /health/ready
+│   └── health.py                    # /health/live and /health/ready
 ├── tests/
 │   ├── test_stress_db_pool.py
 │   ├── test_stress_sse.py
 │   ├── test_stress_thread_pool.py
+│   ├── test_stress_compound_deadlock.py  # Production failure mode
 │   ├── test_stress_mixed.py
 │   └── test_health.py
 stress/
@@ -188,18 +307,20 @@ pip install -e ".[stress]"
 # Unit + health tests (always in CI)
 pytest teredacta/tests/test_health.py -v
 
-# Stress tests (CI or manual)
-pytest teredacta/tests/test_stress_*.py -v
+# Stress tests (on-demand)
+pytest -m stress -v
 
 # Locust (manual, needs running server)
-locust -f stress/locustfile.py --headless -u 50 -r 5 -t 5m --host http://localhost:8000
+locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
 ```
 
 ## 5. Success Criteria
 
 From issue #7:
 
-- Server remains responsive (health endpoint returns 200) under sustained load
-- No thread pool deadlocks
+- Server remains responsive (liveness endpoint returns 200) under sustained load
+- No thread pool deadlocks — compound deadlock test passes
 - Proper error responses (503/504) when overloaded, not silent hangs
-- Clean recovery after load subsides
+- Clean recovery after load subsides — health returns to "healthy" within 15 seconds of load stopping
+- SSE subscribers cleaned up after disconnect (via QueueFull eviction)
+- Health endpoint correctly reports degraded/unhealthy status under load

--- a/docs/superpowers/specs/2026-04-01-stress-test-suite-design.md
+++ b/docs/superpowers/specs/2026-04-01-stress-test-suite-design.md
@@ -1,0 +1,205 @@
+# Stress Test Suite Design
+
+**Issue:** #7 — Enhancement: Build a stress test suite for TEREDACTA  
+**Date:** 2026-04-01  
+**Status:** Approved
+
+## Overview
+
+Comprehensive stress test suite to verify TEREDACTA's stability under load, targeting the failure modes that caused the production hang (all threads deadlocked, no logs, unresponsive server). Two complementary tools: pytest stress tests for CI-runnable regression checks, and locust for realistic sustained load testing against a live server.
+
+## Architecture: Approach C (Locust + Pytest Stress Tests)
+
+- **Pytest stress tests** — fast, deterministic, CI-runnable. Target specific failure modes: DB pool contention, SSE saturation, thread pool exhaustion, mixed workloads.
+- **Locust load tests** — realistic sustained load with composable user profiles. Run manually against localhost (fixture mode) or live VPS.
+
+## 1. Health Endpoint
+
+Two new public async endpoints, no authentication required.
+
+### `GET /health/live` — Liveness Probe
+
+Returns `{"status": "ok"}` with HTTP 200. No dependency checks. Proves the event loop is not deadlocked.
+
+### `GET /health/ready` — Readiness Probe
+
+Returns JSON with component checks:
+
+```json
+{
+  "status": "healthy | degraded | unhealthy",
+  "checks": {
+    "db_pool": {"status": "ok | degraded | error", "available": 6, "max": 8},
+    "sse": {"status": "ok | degraded", "subscribers": 3},
+    "uptime_seconds": 1234
+  }
+}
+```
+
+**Thresholds (8-connection pool):**
+
+| Metric | Healthy | Degraded | Unhealthy |
+|---|---|---|---|
+| DB pool available | ≥3 | 1–2 | 0 or acquire timeout |
+| SSE subscribers | <100 | 100–500 | >500 |
+
+**Design constraints:**
+- Never acquires a DB pool connection — inspects pool queue metadata only
+- Async — does not occupy a thread pool slot
+- 3-second hard timeout via `asyncio.wait_for()` — returns 503 if checks hang
+- Returns HTTP 200 for healthy/degraded, HTTP 503 for unhealthy
+
+**Required change:** Expose `available_count` property on `ConnectionPool` so the health endpoint can inspect pool state without acquiring a connection.
+
+### Implementation
+
+New file: `teredacta/routers/health.py`, mounted in `app.py`.
+
+## 2. Pytest Stress Tests
+
+CI-runnable regression tests targeting specific failure modes. Located in `teredacta/tests/`.
+
+### `test_stress_db_pool.py` — DB Pool Contention
+
+- Spawn 50+ threads all calling `pool.acquire()` simultaneously on an 8-connection pool
+- Verify no deadlocks — all threads complete (with either a connection or a timeout error)
+- Verify pool recovers after burst subsides (connections returned, new acquires succeed)
+- Verify graceful timeout behavior (proper exception, not a hang)
+
+### `test_stress_sse.py` — SSE Connection Saturation
+
+- Open 200+ SSE subscriber queues rapidly
+- Disconnect half ungracefully (abandon without unsubscribe)
+- Verify cleanup — dead queues are detected and removed
+- Verify remaining subscribers still receive events
+- Rapid connect/disconnect cycling (1000 cycles) — verify no resource leak
+
+### `test_stress_thread_pool.py` — Thread Pool Exhaustion
+
+- Submit blocking tasks that saturate the default executor
+- Verify the health endpoint still responds (async, not blocked by executor)
+- Verify SSE polling continues (also async)
+- Verify server returns errors (not hangs) when executor is full
+
+### `test_stress_mixed.py` — Combined Workload
+
+- Simultaneously: HTTP requests to multiple endpoints + SSE subscribers + DB-heavy queries
+- Verify health endpoint reports degraded (not unhealthy) under moderate load
+- Verify clean recovery after load stops — health returns to healthy
+
+### `test_health.py` — Health Endpoint Unit Tests
+
+- Verify response format and status codes
+- Verify threshold transitions (healthy → degraded → unhealthy)
+- Verify 3-second timeout behavior
+- Verify liveness probe works when readiness is unhealthy
+
+### Test Infrastructure
+
+- Synthetic SQLite DB with ~10k documents for non-trivial queries
+- Configurable concurrency levels via pytest parametrize or env vars
+- 30-second timeout on all stress tests (hangs fail as test failures, not infinite waits)
+- `@pytest.mark.stress` marker, excluded from default test runs via `pytest.ini`
+- Real SQLite and real connection pool — no mocks for stressed resources
+
+## 3. Locust Load Tests
+
+Located in `stress/` at project root (separate from unit tests — requires a running server).
+
+### User Classes
+
+**`WebUser`** — Standard page browsing
+- Hits `/`, `/documents`, `/recoveries`, `/highlights`, random document/recovery detail pages
+- Realistic think time (1–5s between requests)
+- Validates responses are 200, not 503 or timeouts
+
+**`SSEUser`** — SSE subscriber (custom User subclass)
+- Authenticates, opens SSE connection to `/sse/stats`
+- Holds connection for random duration (10–60s)
+- Mix of graceful and ungraceful disconnects
+- Tracks events received, connection duration, errors
+
+**`AdminUser`** — Admin operations
+- Authenticates, hits admin endpoints: daemon status, config page, queue, logs
+- Lower weight (fewer admin users than public users)
+
+**`HealthMonitor`** — Continuous health polling
+- Hits `/health/ready` every 2 seconds throughout the run
+- Records status transitions (healthy → degraded → unhealthy)
+- Fails the run if unhealthy is sustained for >30 seconds
+
+### Configuration
+
+- `stress/config.py` — target URL, user counts, spawn rates, run duration
+- Default: fixture mode (localhost:8000 with synthetic data)
+- `--host` flag for live VPS testing
+- Defaults: 50 users, spawn rate 5/s, 5-minute run
+
+### Running
+
+```bash
+# Headless CI mode
+locust -f stress/locustfile.py --headless -u 50 -r 5 -t 5m --host http://localhost:8000
+
+# Web UI for VPS testing
+locust -f stress/locustfile.py --host https://your-vps.example.com
+```
+
+## 4. Dependencies & Project Structure
+
+### New Dependencies
+
+In `pyproject.toml` under `[project.optional-dependencies]`:
+
+```toml
+[project.optional-dependencies]
+stress = [
+    "locust>=2.20.0",
+    "sseclient-py>=1.8.0",
+]
+```
+
+No new core dependencies. Pytest stress tests use only stdlib + existing test deps.
+
+### Project Structure Additions
+
+```
+teredacta/
+├── routers/
+│   └── health.py              # /health/live and /health/ready
+├── tests/
+│   ├── test_stress_db_pool.py
+│   ├── test_stress_sse.py
+│   ├── test_stress_thread_pool.py
+│   ├── test_stress_mixed.py
+│   └── test_health.py
+stress/
+├── locustfile.py
+├── config.py
+└── README.md
+```
+
+### Running
+
+```bash
+# Install stress dependencies
+pip install -e ".[stress]"
+
+# Unit + health tests (always in CI)
+pytest teredacta/tests/test_health.py -v
+
+# Stress tests (CI or manual)
+pytest teredacta/tests/test_stress_*.py -v
+
+# Locust (manual, needs running server)
+locust -f stress/locustfile.py --headless -u 50 -r 5 -t 5m --host http://localhost:8000
+```
+
+## 5. Success Criteria
+
+From issue #7:
+
+- Server remains responsive (health endpoint returns 200) under sustained load
+- No thread pool deadlocks
+- Proper error responses (503/504) when overloaded, not silent hangs
+- Clean recovery after load subsides

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,12 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.2.0",
     "httpx>=0.25.0",
+]
+stress = [
+    "locust>=2.20.0",
+    "sseclient-py>=1.8.0",
 ]
 
 [project.scripts]
@@ -31,3 +36,10 @@ teredacta = "teredacta.__main__:cli"
 
 [tool.setuptools.packages.find]
 include = ["teredacta*"]
+
+[tool.pytest.ini_options]
+markers = [
+    "stress: stress tests (deselected by default, run with: pytest -m stress)",
+]
+addopts = "-m 'not stress'"
+asyncio_mode = "strict"

--- a/stress/README.md
+++ b/stress/README.md
@@ -1,0 +1,76 @@
+# TEREDACTA Stress Tests
+
+Load testing suite using [Locust](https://locust.io/).
+
+## Setup
+
+```bash
+pip install -e ".[stress]"
+```
+
+## Running
+
+### Against local server
+
+Start TEREDACTA locally first:
+```bash
+teredacta run
+```
+
+Then run the stress tests:
+```bash
+# Headless (CI mode) — uses StressTestShape for phases
+locust -f stress/locustfile.py --headless --host http://localhost:8000
+
+# With web UI (interactive)
+locust -f stress/locustfile.py --host http://localhost:8000
+# Then open http://localhost:8089
+```
+
+### Against VPS
+
+```bash
+export STRESS_ADMIN_PASSWORD=your-admin-password
+locust -f stress/locustfile.py --headless --host https://your-vps.example.com
+```
+
+### With web UI
+
+```bash
+locust -f stress/locustfile.py --host https://your-vps.example.com
+```
+Open http://localhost:8089 to configure users, spawn rate, and watch results.
+
+## Load Phases (StressTestShape)
+
+| Phase | Duration | Users | Description |
+|---|---|---|---|
+| Warm-up | 0-30s | 0→200 | Ramp up at 10 users/sec |
+| Sustained | 30s-4m30s | 200 | Full load |
+| Cool-down | 4m30s-5m | 200→0 | Ramp down |
+| Recovery | 5m-5m15s | 1 | Verify health returns to healthy |
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `STRESS_TARGET_HOST` | `http://localhost:8000` | Target server URL |
+| `STRESS_ADMIN_PASSWORD` | `test-password` | Admin password for SSE/admin tests |
+
+## User Profiles
+
+| Profile | Weight | Description |
+|---|---|---|
+| WebUser | 60% | Browses public pages (documents, recoveries, highlights) |
+| SSEUser | 15% | Opens SSE connections, holds 10-60s, mix of graceful/ungraceful disconnects |
+| AdminUser | 20% | Admin dashboard, daemon status, entity index status, config, logs |
+| HealthMonitor | 5% | Polls /health/live and /health/ready, tracks status transitions |
+
+## Success Criteria
+
+- Liveness probe (`/health/live`) never fails
+- Readiness probe (`/health/ready`) does not report "unhealthy" for more than 60 seconds continuously
+- No HTTP 500 errors
+- Server recovers to "healthy" after load subsides

--- a/stress/locustfile.py
+++ b/stress/locustfile.py
@@ -1,0 +1,254 @@
+"""Locust stress test suite for TEREDACTA.
+
+Run headless:
+    locust -f stress/locustfile.py --headless -u 200 -r 10 -t 5m --host http://localhost:8000
+
+Run with Web UI:
+    locust -f stress/locustfile.py --host http://localhost:8000
+"""
+
+import logging
+import math
+import random
+import time
+
+import gevent
+from locust import HttpUser, LoadTestShape, between, events, task
+
+from stress_config import (
+    ADMIN_PASSWORD,
+    ADMIN_USER_WEIGHT,
+    HEALTH_MONITOR_WEIGHT,
+    RAMP_DOWN_SECONDS,
+    RAMP_UP_SECONDS,
+    READINESS_UNHEALTHY_SECONDS,
+    RECOVERY_SECONDS,
+    SSE_MAX_HOLD_SECONDS,
+    SSE_MIN_HOLD_SECONDS,
+    SSE_USER_WEIGHT,
+    SUSTAINED_SECONDS,
+    WEB_USER_WEIGHT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Track health status transitions globally.
+# Safe under gevent: cooperative scheduling, no I/O between read-modify-write.
+_health_tracker = {
+    "last_healthy": time.monotonic(),
+    "unhealthy_since": None,
+    "liveness_failures": 0,
+}
+
+
+class StressTestShape(LoadTestShape):
+    """Custom load shape with warm-up, sustained, cool-down, and recovery phases.
+
+    Phase 1 (0-30s):      Ramp up from 0 to 200 users
+    Phase 2 (30s-4m30s):  Sustained at 200 users
+    Phase 3 (4m30s-5m):   Ramp down from 200 to 0
+    Phase 4 (5m-5m15s):   Recovery — only HealthMonitor users remain
+    """
+    MAX_USERS = 200
+    SPAWN_RATE = 10
+
+    def tick(self):
+        run_time = self.get_run_time()
+
+        if run_time < RAMP_UP_SECONDS:
+            # Phase 1: Ramp up
+            users = min(self.MAX_USERS, math.ceil(run_time * self.SPAWN_RATE))
+            return (users, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS:
+            # Phase 2: Sustained load
+            return (self.MAX_USERS, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS + RAMP_DOWN_SECONDS:
+            # Phase 3: Ramp down
+            elapsed_in_phase = run_time - RAMP_UP_SECONDS - SUSTAINED_SECONDS
+            fraction_remaining = 1 - (elapsed_in_phase / RAMP_DOWN_SECONDS)
+            users = max(1, math.ceil(self.MAX_USERS * fraction_remaining))
+            return (users, self.SPAWN_RATE)
+
+        elif run_time < RAMP_UP_SECONDS + SUSTAINED_SECONDS + RAMP_DOWN_SECONDS + RECOVERY_SECONDS:
+            # Phase 4: Recovery — keep minimal users for health monitoring
+            return (1, 1)
+
+        else:
+            # Done
+            return None
+
+
+class WebUser(HttpUser):
+    """Simulates a visitor browsing public pages."""
+
+    weight = WEB_USER_WEIGHT
+    wait_time = between(1, 5)
+
+    @task(5)
+    def browse_documents(self):
+        page = random.randint(1, 10)
+        self.client.get(f"/documents?page={page}", name="/documents?page=[N]")
+
+    @task(3)
+    def browse_recoveries(self):
+        self.client.get("/recoveries")
+
+    @task(3)
+    def browse_highlights(self):
+        self.client.get("/highlights")
+
+    @task(2)
+    def browse_explore(self):
+        self.client.get("/")
+
+    @task(1)
+    def view_document_detail(self):
+        doc_id = f"doc-{random.randint(1, 100)}"
+        self.client.get(f"/documents/{doc_id}", name="/documents/[id]")
+
+
+class SSEUser(HttpUser):
+    """Simulates an admin subscribing to SSE stats."""
+
+    weight = SSE_USER_WEIGHT
+    # Short wait between reconnections — hold time is inside the task
+    wait_time = between(1, 3)
+
+    def on_start(self):
+        """Authenticate to get admin session cookie."""
+        self.client.post(
+            "/admin/login",
+            data={"password": ADMIN_PASSWORD},
+            name="/admin/login",
+            allow_redirects=False,
+        )
+
+    @task
+    def subscribe_sse(self):
+        """Open SSE connection, hold it, then disconnect."""
+        hold_time = random.uniform(SSE_MIN_HOLD_SECONDS, SSE_MAX_HOLD_SECONDS)
+        start = time.monotonic()
+
+        try:
+            with self.client.get(
+                "/sse/stats",
+                stream=True,
+                timeout=hold_time + 5,  # Hard timeout to prevent blocking beyond hold_time
+                name="/sse/stats",
+                catch_response=True,
+            ) as resp:
+                if resp.status_code == 403:
+                    resp.failure("Not authenticated — SSE returned 403")
+                    return
+                resp.success()
+
+                # Hold connection for the specified duration
+                for line in resp.iter_lines():
+                    if time.monotonic() - start > hold_time:
+                        break
+        except Exception as e:
+            logger.debug("SSE connection ended: %s", e)
+
+
+class AdminUser(HttpUser):
+    """Simulates admin dashboard usage."""
+
+    weight = ADMIN_USER_WEIGHT
+    wait_time = between(2, 8)
+
+    def on_start(self):
+        self.client.post(
+            "/admin/login",
+            data={"password": ADMIN_PASSWORD},
+            name="/admin/login",
+            allow_redirects=False,
+        )
+
+    @task(3)
+    def view_admin_dashboard(self):
+        self.client.get("/admin/")
+
+    @task(2)
+    def check_daemon_status(self):
+        self.client.get("/admin/daemon/status")
+
+    @task(2)
+    def view_entity_index_status(self):
+        self.client.get("/admin/entity-index/status")
+
+    @task(1)
+    def view_config(self):
+        self.client.get("/admin/config")
+
+    @task(1)
+    def view_logs(self):
+        self.client.get("/admin/logs")
+
+
+class HealthMonitor(HttpUser):
+    """Continuously monitors health endpoints."""
+
+    weight = HEALTH_MONITOR_WEIGHT
+    wait_time = between(2, 5)
+
+    @task(3)
+    def check_liveness(self):
+        with self.client.get("/health/live", catch_response=True, name="/health/live") as resp:
+            if resp.status_code != 200:
+                _health_tracker["liveness_failures"] += 1
+                resp.failure(f"LIVENESS FAILURE: {resp.status_code}")
+                logger.error("LIVENESS PROBE FAILED: status=%s", resp.status_code)
+            else:
+                resp.success()
+
+    @task(1)
+    def check_readiness(self):
+        with self.client.get("/health/ready", catch_response=True, name="/health/ready") as resp:
+            now = time.monotonic()
+
+            if resp.status_code == 200:
+                data = resp.json()
+                status = data.get("status", "unknown")
+
+                if status == "healthy":
+                    _health_tracker["last_healthy"] = now
+                    _health_tracker["unhealthy_since"] = None
+                    resp.success()
+                elif status == "degraded":
+                    # Expected under load — log but don't fail
+                    resp.success()
+                    logger.info("Health: degraded")
+                else:
+                    resp.failure(f"Unexpected status: {status}")
+            elif resp.status_code == 503:
+                if _health_tracker["unhealthy_since"] is None:
+                    _health_tracker["unhealthy_since"] = now
+                    logger.warning("Health: unhealthy (started)")
+
+                duration = now - _health_tracker["unhealthy_since"]
+                if duration > READINESS_UNHEALTHY_SECONDS:
+                    resp.failure(
+                        f"UNHEALTHY for {duration:.0f}s (threshold: {READINESS_UNHEALTHY_SECONDS}s)"
+                    )
+                else:
+                    resp.success()
+            else:
+                resp.failure(f"Unexpected status code: {resp.status_code}")
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    """Report health summary at end of test. process_exit_code only works in headless mode."""
+    tracker = _health_tracker
+    logger.info("=== Health Summary ===")
+    logger.info("Liveness failures: %d", tracker["liveness_failures"])
+    if tracker["unhealthy_since"]:
+        logger.warning("Server was unhealthy at test end")
+    else:
+        logger.info("Server was healthy at test end")
+
+    if tracker["liveness_failures"] > 0:
+        logger.error("TEST FAILED: Liveness probe failures detected")
+        environment.process_exit_code = 1

--- a/stress/locustfile.py
+++ b/stress/locustfile.py
@@ -12,7 +12,6 @@ import math
 import random
 import time
 
-import gevent
 from locust import HttpUser, LoadTestShape, between, events, task
 
 from stress_config import (

--- a/stress/stress_config.py
+++ b/stress/stress_config.py
@@ -1,0 +1,29 @@
+"""Configuration for locust stress tests."""
+
+import os
+
+# Target server
+TARGET_HOST = os.environ.get("STRESS_TARGET_HOST", "http://localhost:8000")
+
+# Admin credentials for SSE and admin endpoints
+ADMIN_PASSWORD = os.environ.get("STRESS_ADMIN_PASSWORD", "test-password")
+
+# User class weights (must sum to 100)
+WEB_USER_WEIGHT = 60
+SSE_USER_WEIGHT = 15
+ADMIN_USER_WEIGHT = 20
+HEALTH_MONITOR_WEIGHT = 5
+
+# Health monitoring thresholds
+LIVENESS_FAILURE_SECONDS = 0  # Any liveness failure is critical
+READINESS_UNHEALTHY_SECONDS = 60  # Sustained unhealthy = test failure
+
+# SSE connection parameters
+SSE_MIN_HOLD_SECONDS = 10
+SSE_MAX_HOLD_SECONDS = 60
+
+# Load test phases (seconds)
+RAMP_UP_SECONDS = 30
+SUSTAINED_SECONDS = 240
+RAMP_DOWN_SECONDS = 30
+RECOVERY_SECONDS = 15

--- a/teredacta/app.py
+++ b/teredacta/app.py
@@ -19,6 +19,8 @@ class _HealthLogFilter(logging.Filter):
         if " /health/" in msg:
             return False
         return True
+
+
 from teredacta.auth import AuthManager
 from teredacta.config import TeredactaConfig
 from teredacta.entity_index import EntityIndex

--- a/teredacta/app.py
+++ b/teredacta/app.py
@@ -1,6 +1,7 @@
 from contextlib import asynccontextmanager
 from pathlib import Path
 import logging
+import time
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -45,10 +46,12 @@ def create_app(config: TeredactaConfig) -> FastAPI:
         response = await call_next(request)
         return response
 
-    from teredacta.routers import dashboard, documents, groups, recoveries, pdf, queue, summary, admin, explore, highlights, api
+    from teredacta.routers import dashboard, documents, groups, recoveries, pdf, queue, summary, admin, explore, highlights, api, health
 
     # SSE at root (admin-only, guarded in dashboard.py)
     app.include_router(dashboard.sse_router)
+    app.include_router(health.router, prefix="/health")
+    app.state.startup_time = time.monotonic()
 
     # API endpoints (HTML fragments)
     app.include_router(api.router, prefix="/api")

--- a/teredacta/app.py
+++ b/teredacta/app.py
@@ -9,6 +9,16 @@ from fastapi.templating import Jinja2Templates
 from starlette.responses import HTMLResponse
 
 logger = logging.getLogger(__name__)
+
+
+class _HealthLogFilter(logging.Filter):
+    """Suppress access log entries for /health/* requests."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        if " /health/" in msg:
+            return False
+        return True
 from teredacta.auth import AuthManager
 from teredacta.config import TeredactaConfig
 from teredacta.entity_index import EntityIndex
@@ -19,6 +29,10 @@ def create_app(config: TeredactaConfig) -> FastAPI:
     async def lifespan(application: FastAPI):
         yield
         application.state.unob.close()
+
+    _access_logger = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, _HealthLogFilter) for f in _access_logger.filters):
+        _access_logger.addFilter(_HealthLogFilter())
 
     app = FastAPI(title="TEREDACTA", docs_url=None, redoc_url=None, lifespan=lifespan)
     app.state.config = config

--- a/teredacta/config.py
+++ b/teredacta/config.py
@@ -27,6 +27,8 @@ class TeredactaConfig:
     session_timeout_minutes: int = 60
     sse_poll_interval_seconds: int = 2
     subprocess_timeout_seconds: int = 60
+    health_pool_degraded_threshold: int = 3  # idle+uncreated <= this = degraded
+    health_sse_degraded_threshold: int = 20  # subscribers >= this = degraded
     # NOTE: Default generates a random key on every process start, which
     # invalidates all existing sessions on restart. Persist a secret_key in
     # your config file (teredacta.yaml) to preserve sessions across restarts.

--- a/teredacta/db_pool.py
+++ b/teredacta/db_pool.py
@@ -87,3 +87,14 @@ class ConnectionPool:
                 conn.close()
             except queue.Empty:
                 break
+
+    def pool_status(self) -> dict:
+        """Return pool metrics without acquiring a connection.
+
+        Reads _size and _pool.qsize() which are approximate under
+        contention (CPython GIL makes individual reads atomic, but the
+        pair is not a snapshot). Acceptable for health monitoring.
+        """
+        idle = self._pool.qsize()
+        size = self._size
+        return {"idle": idle, "in_use": max(0, size - idle), "capacity": self._max_size}

--- a/teredacta/routers/health.py
+++ b/teredacta/routers/health.py
@@ -49,7 +49,7 @@ async def _readiness_checks(request: Request) -> JSONResponse:
     sub_count = sse.subscriber_count if sse else 0
     sse_degraded = config.health_sse_degraded_threshold
     sse_unhealthy = sse_degraded * 5
-    if sub_count >= sse_unhealthy:
+    if sub_count > sse_unhealthy:
         sse_status = "error"
     elif sub_count >= sse_degraded:
         sse_status = "degraded"

--- a/teredacta/routers/health.py
+++ b/teredacta/routers/health.py
@@ -1,0 +1,83 @@
+"""Health check endpoints for liveness and readiness probes."""
+
+import asyncio
+import os
+import time
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+@router.get("/live")
+async def liveness():
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness(request: Request):
+    try:
+        result = await asyncio.wait_for(_readiness_checks(request), timeout=1.0)
+        return result
+    except asyncio.TimeoutError:
+        return JSONResponse({"status": "unhealthy"}, status_code=503)
+
+
+async def _readiness_checks(request: Request) -> JSONResponse:
+    config = request.app.state.config
+    unob = request.app.state.unob
+    sse = getattr(request.app.state, "sse", None)
+    client_host = getattr(request.client, "host", None) if request.client else None
+    is_local = client_host in ("127.0.0.1", "localhost", "::1", "testclient")
+    is_admin = getattr(request.state, "is_admin", False)
+    show_details = is_local or is_admin
+
+    pool_data = unob.pool_status()
+    if pool_data is None:
+        pool_check = {"status": "ok", "idle": 0, "in_use": 0, "capacity": 0}
+    else:
+        available = pool_data["capacity"] - pool_data["in_use"]
+        if available >= config.health_pool_degraded_threshold:
+            pool_status = "ok"
+        elif available >= 1:
+            pool_status = "degraded"
+        else:
+            pool_status = "error"
+        pool_check = {"status": pool_status, **pool_data}
+
+    sub_count = sse.subscriber_count if sse else 0
+    sse_degraded = config.health_sse_degraded_threshold
+    sse_unhealthy = sse_degraded * 5
+    if sub_count >= sse_unhealthy:
+        sse_status = "error"
+    elif sub_count >= sse_degraded:
+        sse_status = "degraded"
+    else:
+        sse_status = "ok"
+    sse_check = {"status": sse_status, "subscribers": sub_count}
+
+    statuses = [pool_check["status"], sse_check["status"]]
+    if "error" in statuses:
+        overall = "unhealthy"
+    elif "degraded" in statuses:
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    status_code = 503 if overall == "unhealthy" else 200
+
+    if show_details:
+        body = {
+            "status": overall,
+            "worker_pid": os.getpid(),
+            "checks": {
+                "db_pool": pool_check,
+                "sse": sse_check,
+                "uptime_seconds": round(time.monotonic() - request.app.state.startup_time, 1),
+            },
+        }
+    else:
+        body = {"status": overall}
+
+    return JSONResponse(body, status_code=status_code)

--- a/teredacta/sse.py
+++ b/teredacta/sse.py
@@ -16,6 +16,10 @@ class SSEManager:
         self._task: Optional[asyncio.Task] = None
         self._last_stats: Optional[dict] = None
 
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
     def subscribe(self) -> asyncio.Queue:
         queue = asyncio.Queue(maxsize=100)
         self._subscribers.add(queue)

--- a/teredacta/tests/conftest.py
+++ b/teredacta/tests/conftest.py
@@ -204,3 +204,30 @@ def app_with_entities(test_config, entity_index, entity_db_path):
 def client_with_entities(app_with_entities):
     """TestClient with entity index available."""
     return TestClient(app_with_entities)
+
+
+# ---------------------------------------------------------------------------
+# Stress test fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def stress_db(mock_db):
+    """Reuse mock_db schema with optional seed data for stress tests."""
+    return mock_db
+
+
+@pytest.fixture
+def stress_app(tmp_dir, stress_db):
+    """App for stress tests using the shared mock_db schema."""
+    cfg = TeredactaConfig(
+        unobfuscator_path=str(tmp_dir),
+        unobfuscator_bin="echo",
+        db_path=str(stress_db),
+        pdf_cache_dir=str(tmp_dir / "pdf_cache"),
+        output_dir=str(tmp_dir / "output"),
+        log_path=str(tmp_dir / "unobfuscator.log"),
+        host="127.0.0.1",
+        port=8000,
+    )
+    from teredacta.app import create_app
+    return create_app(cfg)

--- a/teredacta/tests/test_health.py
+++ b/teredacta/tests/test_health.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 import pytest
+from fastapi.testclient import TestClient
 
 from teredacta.db_pool import ConnectionPool
 
@@ -97,3 +98,89 @@ class TestHealthConfig:
         )
         assert cfg.health_pool_degraded_threshold == 5
         assert cfg.health_sse_degraded_threshold == 50
+
+
+class TestHealthEndpoints:
+    @pytest.fixture
+    def health_client(self, tmp_path):
+        """Create a test client with a real DB for health tests."""
+        db_path = tmp_path / "test.db"
+        sqlite3.connect(str(db_path)).close()
+        cfg = TeredactaConfig(
+            unobfuscator_path=str(tmp_path),
+            unobfuscator_bin="echo",
+            db_path=str(db_path),
+            pdf_cache_dir=str(tmp_path / "pdf_cache"),
+            output_dir=str(tmp_path / "output"),
+            log_path=str(tmp_path / "unobfuscator.log"),
+            host="127.0.0.1",
+            port=8000,
+        )
+        (tmp_path / "pdf_cache").mkdir(exist_ok=True)
+        (tmp_path / "output").mkdir(exist_ok=True)
+        (tmp_path / "unobfuscator.log").touch()
+        from teredacta.app import create_app
+        app = create_app(cfg)
+        return TestClient(app)
+
+    def test_liveness_returns_ok(self, health_client):
+        resp = health_client.get("/health/live")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_readiness_healthy_before_any_queries(self, health_client):
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"
+
+    def test_readiness_includes_details_from_localhost(self, health_client):
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "checks" in data
+        assert "db_pool" in data["checks"]
+        assert "sse" in data["checks"]
+        assert "uptime_seconds" in data["checks"]
+        assert "worker_pid" in data
+
+    def test_readiness_pool_none_is_healthy(self, health_client):
+        resp = health_client.get("/health/ready")
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["checks"]["db_pool"]["status"] == "ok"
+
+    def test_readiness_returns_503_when_unhealthy(self, health_client):
+        app = health_client.app
+        unob = app.state.unob
+        conns = []
+        for _ in range(8):
+            conns.append(unob._get_db())
+        resp = health_client.get("/health/ready")
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["status"] == "unhealthy"
+        assert data["checks"]["db_pool"]["idle"] == 0
+        assert data["checks"]["db_pool"]["in_use"] == 8
+        for c in conns:
+            unob._release_db(c)
+
+    def test_liveness_works_when_readiness_unhealthy(self, health_client):
+        app = health_client.app
+        unob = app.state.unob
+        conns = [unob._get_db() for _ in range(8)]
+        assert health_client.get("/health/ready").status_code == 503
+        resp = health_client.get("/health/live")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+        for c in conns:
+            unob._release_db(c)
+
+    def test_readiness_timeout_returns_503(self, health_client):
+        import asyncio
+        from unittest.mock import patch
+        async def slow_checks(*args, **kwargs):
+            await asyncio.sleep(5)
+        with patch("teredacta.routers.health._readiness_checks", slow_checks):
+            resp = health_client.get("/health/ready")
+            assert resp.status_code == 503
+            assert resp.json()["status"] == "unhealthy"

--- a/teredacta/tests/test_health.py
+++ b/teredacta/tests/test_health.py
@@ -1,0 +1,99 @@
+"""Tests for health endpoint and pool_status."""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from teredacta.db_pool import ConnectionPool
+
+
+class TestPoolStatus:
+    def test_pool_status_empty_pool(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 0, "capacity": 4}
+        pool.close()
+
+    def test_pool_status_one_acquired(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        conn = pool.acquire()
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 1, "capacity": 4}
+        pool.release(conn)
+        pool.close()
+
+    def test_pool_status_acquire_and_release(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=4)
+        conn = pool.acquire()
+        pool.release(conn)
+        status = pool.pool_status()
+        assert status == {"idle": 1, "in_use": 0, "capacity": 4}
+        pool.close()
+
+    def test_pool_status_fully_acquired(self, tmp_path):
+        db = tmp_path / "test.db"
+        sqlite3.connect(str(db)).close()
+        pool = ConnectionPool(str(db), max_size=2)
+        c1 = pool.acquire()
+        c2 = pool.acquire()
+        status = pool.pool_status()
+        assert status == {"idle": 0, "in_use": 2, "capacity": 2}
+        pool.release(c1)
+        pool.release(c2)
+        pool.close()
+
+
+import asyncio
+from teredacta.config import TeredactaConfig
+from teredacta.sse import SSEManager
+
+
+class TestSSESubscriberCount:
+    """Tests must be async because SSEManager.subscribe() calls asyncio.create_task()."""
+
+    @pytest.mark.asyncio
+    async def test_subscriber_count_zero(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_subscriber_count_after_subscribe(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        q = sse.subscribe()
+        assert sse.subscriber_count == 1
+        sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_subscriber_count_multiple(self):
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        q1 = sse.subscribe()
+        q2 = sse.subscribe()
+        assert sse.subscriber_count == 2
+        sse.unsubscribe(q1)
+        assert sse.subscriber_count == 1
+        sse.unsubscribe(q2)
+        assert sse.subscriber_count == 0
+
+
+class TestHealthConfig:
+    def test_default_health_thresholds(self):
+        cfg = TeredactaConfig()
+        assert cfg.health_pool_degraded_threshold == 3
+        assert cfg.health_sse_degraded_threshold == 20
+
+    def test_custom_health_thresholds(self):
+        cfg = TeredactaConfig(
+            health_pool_degraded_threshold=5,
+            health_sse_degraded_threshold=50,
+        )
+        assert cfg.health_pool_degraded_threshold == 5
+        assert cfg.health_sse_degraded_threshold == 50

--- a/teredacta/tests/test_stress_compound_deadlock.py
+++ b/teredacta/tests/test_stress_compound_deadlock.py
@@ -115,10 +115,10 @@ class TestCompoundDeadlock:
         ) as client:
             resp = await client.get("/health/ready")
             data = resp.json()
-            # With 7 held, available = capacity(8) - in_use(7 or 8) <= 1
-            # Status should be degraded or unhealthy (the request itself may use a connection)
-            assert data["status"] in ("degraded", "unhealthy")
-            assert data["checks"]["db_pool"]["in_use"] >= 7
+            # With 7 held, available = capacity(8) - in_use(7) = 1
+            # The health endpoint never acquires a DB connection (design constraint)
+            assert data["status"] == "degraded"
+            assert data["checks"]["db_pool"]["in_use"] == 7
 
         for c in held:
             unob._release_db(c)

--- a/teredacta/tests/test_stress_compound_deadlock.py
+++ b/teredacta/tests/test_stress_compound_deadlock.py
@@ -1,0 +1,133 @@
+"""Stress test reproducing the production compound deadlock.
+
+The production hang was: all default executor threads blocked on
+pool.acquire() (30s timeout) while SSE poll and admin requests
+also need executor threads. This test verifies:
+1. The event loop stays responsive during compound contention
+2. The system recovers after holds are released
+"""
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import pytest_asyncio
+import httpx
+
+from teredacta.db_pool import ConnectionPool
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestCompoundDeadlock:
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def pin_executor(self):
+        """Pin executor to 8 threads (same as pool size) and restore after."""
+        loop = asyncio.get_running_loop()
+        original_executor = loop._default_executor
+        small_executor = ThreadPoolExecutor(max_workers=8)
+        loop.set_default_executor(small_executor)
+        yield small_executor
+        if original_executor is not None:
+            loop.set_default_executor(original_executor)
+        small_executor.shutdown(wait=False, cancel_futures=True)
+
+    @pytest.mark.asyncio
+    async def test_event_loop_survives_compound_deadlock(self, stress_app, stress_db):
+        """Event loop stays responsive even when executor + pool are both saturated."""
+        loop = asyncio.get_running_loop()
+
+        # Create a pool we can control
+        pool = ConnectionPool(str(stress_db), max_size=8, read_only=True)
+
+        # Phase 1: Hold all 8 pool connections
+        held_conns = [pool.acquire(timeout=5.0) for _ in range(8)]
+        assert pool.pool_status()["in_use"] == 8
+
+        # Phase 2: Saturate executor with tasks trying to acquire pool connections
+        # These will all block for up to 2 seconds waiting for a connection
+        blocked_futures = []
+        for _ in range(8):
+            fut = loop.run_in_executor(
+                None,
+                lambda: pool.acquire(timeout=2.0),
+            )
+            blocked_futures.append(fut)
+
+        # Give executor threads time to start blocking
+        await asyncio.sleep(0.5)
+
+        # Phase 3: Verify event loop is still alive
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stress_app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await asyncio.wait_for(
+                client.get("/health/live"),
+                timeout=2.0,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "ok"
+
+        # Phase 4: Release all held connections
+        for conn in held_conns:
+            pool.release(conn)
+
+        # Phase 5: Wait for blocked futures to resolve
+        results = await asyncio.gather(*blocked_futures, return_exceptions=True)
+
+        # Some may have acquired (after release), some may have timed out
+        acquired = [r for r in results if not isinstance(r, Exception)]
+
+        # Release any that acquired
+        for conn in acquired:
+            pool.release(conn)
+
+        # Phase 6: Verify recovery
+        status = pool.pool_status()
+        assert status["in_use"] == 0
+
+        # New acquire should work instantly
+        conn = pool.acquire(timeout=1.0)
+        pool.release(conn)
+
+        pool.close()
+
+    @pytest.mark.asyncio
+    async def test_health_reports_degraded_during_contention(self, stress_app):
+        """Health endpoint reports correct status during compound contention."""
+        unob = stress_app.state.unob
+
+        # Force pool creation by making a query
+        conn = unob._get_db()
+        unob._release_db(conn)
+
+        # Hold all but 1 connection
+        held = []
+        for _ in range(7):
+            held.append(unob._get_db())
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stress_app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            # With 7 held, available = capacity(8) - in_use(7 or 8) <= 1
+            # Status should be degraded or unhealthy (the request itself may use a connection)
+            assert data["status"] in ("degraded", "unhealthy")
+            assert data["checks"]["db_pool"]["in_use"] >= 7
+
+        for c in held:
+            unob._release_db(c)
+
+        # After release — should be healthy again
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=stress_app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            assert data["status"] == "healthy"

--- a/teredacta/tests/test_stress_db_pool.py
+++ b/teredacta/tests/test_stress_db_pool.py
@@ -1,0 +1,124 @@
+"""Stress tests for DB connection pool under contention."""
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from teredacta.db_pool import ConnectionPool
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestDBPoolContention:
+    @pytest.fixture
+    def stress_db(self, tmp_path):
+        """Create a DB with enough data for non-trivial queries."""
+        db_path = tmp_path / "stress.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE documents ("
+            "id TEXT PRIMARY KEY, source TEXT, extracted_text TEXT, "
+            "text_processed BOOLEAN DEFAULT 0, pdf_processed BOOLEAN DEFAULT 0, "
+            "original_filename TEXT, page_count INTEGER, size_bytes INTEGER)"
+        )
+        # Insert 100k rows for meaningful query pressure
+        rows = [
+            (f"doc-{i}", f"source-{i % 10}", f"text content for document {i} " * 50,
+             i % 3 == 0, i % 5 == 0, f"file_{i}.pdf", (i % 20) + 1, (i % 1000) * 1024)
+            for i in range(100_000)
+        ]
+        conn.executemany(
+            "INSERT INTO documents VALUES (?, ?, ?, ?, ?, ?, ?, ?)", rows
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    @pytest.fixture
+    def pool(self, stress_db):
+        p = ConnectionPool(str(stress_db), max_size=8, read_only=True)
+        yield p
+        p.close()
+
+    def test_50_threads_no_deadlock(self, pool, stress_db):
+        """50 threads compete for 8 connections — all must complete."""
+        results = []
+        errors = []
+
+        def worker(thread_id):
+            try:
+                conn = pool.acquire(timeout=10.0)
+                try:
+                    # Simulate a non-trivial query
+                    row = conn.execute(
+                        "SELECT COUNT(*) FROM documents WHERE extracted_text LIKE ?",
+                        (f"%document {thread_id % 100}%",),
+                    ).fetchone()
+                    results.append((thread_id, row[0]))
+                finally:
+                    pool.release(conn)
+            except TimeoutError:
+                results.append((thread_id, "timeout"))
+            except Exception as e:
+                errors.append((thread_id, str(e)))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        # All threads must have completed (not hung)
+        assert len(results) + len(errors) == 50, (
+            f"Only {len(results) + len(errors)}/50 threads completed"
+        )
+        assert not errors, f"Unexpected errors: {errors}"
+
+    def test_pool_recovers_after_burst(self, pool, stress_db):
+        """After a burst of contention, pool returns to normal."""
+        # Phase 1: burst — hold all connections for 1 second
+        held = []
+        for _ in range(8):
+            held.append(pool.acquire(timeout=5.0))
+
+        status_during = pool.pool_status()
+        assert status_during["idle"] == 0
+        assert status_during["in_use"] == 8
+
+        # Release all
+        for conn in held:
+            pool.release(conn)
+
+        # Phase 2: verify recovery
+        status_after = pool.pool_status()
+        assert status_after["idle"] == 8
+        assert status_after["in_use"] == 0
+
+        # New acquire should succeed instantly
+        conn = pool.acquire(timeout=1.0)
+        pool.release(conn)
+
+    def test_timeout_error_no_leak(self, pool, stress_db):
+        """TimeoutError on acquire does not leak connections."""
+        # Hold all 8
+        held = []
+        for _ in range(8):
+            held.append(pool.acquire(timeout=5.0))
+
+        # Short-timeout acquire should raise TimeoutError
+        with pytest.raises(TimeoutError):
+            pool.acquire(timeout=0.5)
+
+        # Pool status should still show 8 in use (not 9)
+        status = pool.pool_status()
+        assert status["in_use"] == 8
+        assert status["capacity"] == 8
+
+        for conn in held:
+            pool.release(conn)
+
+        # After release, all 8 should be idle
+        status = pool.pool_status()
+        assert status["idle"] == 8

--- a/teredacta/tests/test_stress_mixed.py
+++ b/teredacta/tests/test_stress_mixed.py
@@ -1,0 +1,105 @@
+"""Stress tests for mixed concurrent workloads."""
+
+import asyncio
+import sqlite3
+
+import pytest
+import httpx
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestMixedWorkload:
+
+    @pytest.fixture
+    def seeded_app(self, stress_app, stress_db):
+        """Seed the stress_db with document data for mixed workload."""
+        conn = sqlite3.connect(str(stress_db))
+        rows = [
+            (f"doc-{i}", f"source-{i % 5}", f"text content {i} " * 20,
+             1, 0, f"file_{i}.pdf", (i % 10) + 1, i * 100)
+            for i in range(1000)
+        ]
+        conn.executemany(
+            "INSERT OR IGNORE INTO documents "
+            "(id, source, extracted_text, text_processed, pdf_processed, "
+            "original_filename, page_count, size_bytes) VALUES (?,?,?,?,?,?,?,?)", rows
+        )
+        conn.commit()
+        conn.close()
+        return stress_app
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_and_sse(self, seeded_app):
+        """Simultaneous HTTP requests + SSE subscribers don't deadlock."""
+        errors = []
+
+        async def make_requests(client, n):
+            for i in range(n):
+                try:
+                    resp = await client.get("/documents")
+                    if resp.status_code not in (200, 307, 503):
+                        errors.append(f"GET /documents returned {resp.status_code}")
+                except Exception as e:
+                    errors.append(f"request error: {e}")
+
+        async def subscribe_sse(client):
+            """Subscribe to SSE briefly — expects 403 (no admin session)."""
+            try:
+                resp = await asyncio.wait_for(
+                    client.get("/sse/stats"), timeout=5.0
+                )
+            except (Exception, asyncio.TimeoutError):
+                pass
+
+        async def check_health(client, results):
+            for _ in range(5):
+                resp = await client.get("/health/ready")
+                results.append(resp.json())
+                await asyncio.sleep(0.2)
+
+        health_results = []
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=seeded_app),
+            base_url="http://testserver",
+        ) as client:
+            # Launch mixed workload with timeout to prevent hangs
+            await asyncio.wait_for(
+                asyncio.gather(
+                    make_requests(client, 10),
+                    make_requests(client, 10),
+                    make_requests(client, 10),
+                    subscribe_sse(client),
+                    subscribe_sse(client),
+                    check_health(client, health_results),
+                ),
+                timeout=60.0,
+            )
+
+        assert not errors, f"Errors during mixed workload: {errors}"
+        # Health should have been healthy throughout (light load)
+        for result in health_results:
+            assert result["status"] in ("healthy", "degraded")
+
+    @pytest.mark.asyncio
+    async def test_recovery_after_load(self, seeded_app):
+        """Health returns to healthy after load subsides."""
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=seeded_app),
+            base_url="http://testserver",
+        ) as client:
+            # Phase 1: Apply load
+            tasks = []
+            for _ in range(10):
+                tasks.append(client.get("/documents"))
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=30.0)
+
+            # Phase 2: Wait briefly for things to settle
+            await asyncio.sleep(0.5)
+
+            # Phase 3: Check health
+            resp = await client.get("/health/ready")
+            data = resp.json()
+            assert data["status"] == "healthy"

--- a/teredacta/tests/test_stress_sse.py
+++ b/teredacta/tests/test_stress_sse.py
@@ -1,0 +1,133 @@
+"""Stress tests for SSE connection saturation and cleanup."""
+
+import asyncio
+
+import pytest
+
+from teredacta.sse import SSEManager
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestSSESaturation:
+    """All tests are async because SSEManager.subscribe() calls asyncio.create_task()."""
+
+    @pytest.mark.asyncio
+    async def test_200_subscribers_no_leak(self):
+        """Open 200 subscribers, unsubscribe all, verify cleanup."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        queues = [sse.subscribe() for _ in range(200)]
+        assert sse.subscriber_count == 200
+
+        for q in queues:
+            sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_ungraceful_disconnect_cleanup_via_poll_loop(self):
+        """Abandoned queues are cleaned up by the real _poll_loop broadcast."""
+        from unittest.mock import MagicMock
+
+        # Create a mock unob that returns changing stats each call
+        mock_unob = MagicMock()
+        call_count = 0
+        def changing_stats():
+            nonlocal call_count
+            call_count += 1
+            return {"total_documents": call_count}
+        def changing_daemon():
+            return "running"
+        mock_unob.get_stats = changing_stats
+        mock_unob.get_daemon_status = changing_daemon
+
+        sse = SSEManager(poll_interval=0.01, unob=mock_unob)
+
+        # Subscribe 10 queues — 5 active (we drain), 5 abandoned
+        active_queues = []
+        abandoned_queues = []
+        for i in range(10):
+            q = sse.subscribe()
+            if i < 5:
+                active_queues.append(q)
+            else:
+                abandoned_queues.append(q)
+
+        assert sse.subscriber_count == 10
+
+        # Let the real poll loop run and broadcast events.
+        # Drain active queues aggressively so they don't fill up.
+        # Abandoned queues will fill (maxsize=100) and get evicted.
+        for _ in range(150):
+            await asyncio.sleep(0.02)
+            # Drain ALL pending items from active queues
+            for q in active_queues:
+                while not q.empty():
+                    try:
+                        q.get_nowait()
+                    except asyncio.QueueEmpty:
+                        break
+
+        # Abandoned queues should have been evicted by _poll_loop
+        assert sse.subscriber_count == 5
+
+        for q in active_queues:
+            sse.unsubscribe(q)
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_rapid_connect_disconnect_cycle(self):
+        """1000 rapid subscribe/unsubscribe cycles with no resource leak."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+
+        for _ in range(1000):
+            q = sse.subscribe()
+            sse.unsubscribe(q)
+
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_subscribe_without_iterating_persists(self):
+        """A queue subscribed but never iterated persists until QueueFull.
+
+        This documents the known behavior: if subscribe() is called
+        but the StreamingResponse generator never starts, the queue
+        stays in _subscribers until broadcasts fill it to capacity (100).
+        """
+        sse = SSEManager(poll_interval=1.0, unob=None)
+        orphan = sse.subscribe()
+
+        # The orphan queue exists
+        assert sse.subscriber_count == 1
+
+        # Fill to capacity (maxsize=100). subscribe() doesn't put
+        # anything in the queue, so we need 100 puts to fill it.
+        for i in range(100):
+            orphan.put_nowait(f"data: {i}\n\n")
+
+        # Still there (full but not yet evicted — eviction happens on next broadcast)
+        assert sse.subscriber_count == 1
+
+        # One more triggers QueueFull — simulating what _poll_loop does
+        dead = []
+        try:
+            orphan.put_nowait("data: overflow\n\n")
+        except asyncio.QueueFull:
+            dead.append(orphan)
+        for q in dead:
+            sse._subscribers.discard(q)
+
+        assert sse.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_subscribe_unsubscribe(self):
+        """Concurrent async subscribe/unsubscribe is safe."""
+        sse = SSEManager(poll_interval=1.0, unob=None)
+
+        async def churn(n):
+            for _ in range(n):
+                q = sse.subscribe()
+                await asyncio.sleep(0)  # yield to other tasks
+                sse.unsubscribe(q)
+
+        await asyncio.gather(*[churn(100) for _ in range(10)])
+        assert sse.subscriber_count == 0

--- a/teredacta/tests/test_stress_thread_pool.py
+++ b/teredacta/tests/test_stress_thread_pool.py
@@ -1,0 +1,85 @@
+"""Stress tests for thread pool exhaustion scenarios."""
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import pytest_asyncio
+import httpx
+
+
+@pytest.mark.stress
+@pytest.mark.timeout(90)
+class TestThreadPoolExhaustion:
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def pin_executor(self):
+        """Pin executor to small size and restore original after test."""
+        loop = asyncio.get_running_loop()
+        original_executor = loop._default_executor
+        small_executor = ThreadPoolExecutor(max_workers=4)
+        loop.set_default_executor(small_executor)
+        yield small_executor
+        # Restore original executor (may be None on fresh loops)
+        if original_executor is not None:
+            loop.set_default_executor(original_executor)
+        small_executor.shutdown(wait=False, cancel_futures=True)
+
+    @pytest.mark.asyncio
+    async def test_liveness_responds_when_executor_saturated(self, stress_app, pin_executor):
+        """Liveness probe works even when executor threads are all blocked."""
+        loop = asyncio.get_running_loop()
+
+        # Saturate the executor with short blocking tasks (2s, not 10s)
+        barrier = threading.Event()
+        futures = []
+        for _ in range(4):
+            fut = loop.run_in_executor(None, lambda: barrier.wait(timeout=2.0))
+            futures.append(fut)
+
+        try:
+            await asyncio.sleep(0.3)
+
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=stress_app),
+                base_url="http://testserver",
+            ) as client:
+                resp = await asyncio.wait_for(
+                    client.get("/health/live"),
+                    timeout=3.0,
+                )
+                assert resp.status_code == 200
+                assert resp.json()["status"] == "ok"
+        finally:
+            barrier.set()  # Unblock all threads
+            await asyncio.gather(*futures, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_readiness_responds_when_executor_saturated(self, stress_app, pin_executor):
+        """Readiness probe works even when executor threads are all blocked."""
+        loop = asyncio.get_running_loop()
+        barrier = threading.Event()
+
+        futures = []
+        for _ in range(4):
+            fut = loop.run_in_executor(None, lambda: barrier.wait(timeout=2.0))
+            futures.append(fut)
+
+        try:
+            await asyncio.sleep(0.3)
+
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=stress_app),
+                base_url="http://testserver",
+            ) as client:
+                resp = await asyncio.wait_for(
+                    client.get("/health/ready"),
+                    timeout=3.0,
+                )
+                assert resp.status_code == 200
+                assert resp.json()["status"] == "healthy"
+        finally:
+            barrier.set()
+            await asyncio.gather(*futures, return_exceptions=True)

--- a/teredacta/unob.py
+++ b/teredacta/unob.py
@@ -142,6 +142,12 @@ class UnobInterface:
         else:
             conn.close()
 
+    def pool_status(self) -> dict | None:
+        """Return DB pool metrics, or None if pool not yet initialized."""
+        if self._pool is None:
+            return None
+        return self._pool.pool_status()
+
     def close(self):
         if self._pool:
             self._pool.close()

--- a/teredacta/unob.py
+++ b/teredacta/unob.py
@@ -161,9 +161,13 @@ class UnobInterface:
         try:
             conn.execute("PRAGMA busy_timeout = 10000")
             for idx_name, table, column in self._INDEXES:
-                conn.execute(
-                    f"CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column})"
-                )
+                try:
+                    conn.execute(
+                        f"CREATE INDEX IF NOT EXISTS {idx_name} ON {table}({column})"
+                    )
+                except sqlite3.OperationalError:
+                    # Table does not exist yet — skip index creation for now.
+                    pass
             conn.commit()
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

- Add `/health/live` (liveness) and `/health/ready` (readiness) endpoints with DB pool + SSE threshold monitoring, 1-second timeout, and detail gating for localhost/admin
- Add 14 pytest stress tests covering DB pool contention (50 threads vs 8 connections), SSE saturation (200+ subscribers, broadcast eviction), thread pool exhaustion (pinned executor), compound deadlock (production failure mode reproduction), and mixed workloads
- Add locust load test suite with 4 user profiles, `LoadTestShape` phases (warm-up/sustained/cool-down/recovery), and health monitoring
- Add `pytest-timeout`, stress marker config, and `stress` optional dependency group

## Test plan

- [x] All 312 existing tests pass (no regressions)
- [x] All 14 new stress tests pass (`pytest -m stress`)
- [ ] Run locust against VPS: `locust -f stress/locustfile.py --headless --host https://your-vps`
- [ ] Verify `/health/live` and `/health/ready` return expected responses on VPS
- [ ] Configure Caddy health check per `deploy/README.md`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)